### PR TITLE
Refresh worksheet UI with friendlier styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,15 +61,42 @@ function App(): React.ReactElement {
 
   return (
     <>
-      <div className="min-h-screen bg-gray-50 no-print">
+      <div className="relative min-h-screen no-print">
         <Header />
-        <main className="py-8">
-          <Container>
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <main className="relative z-10 py-12">
+          <Container className="space-y-10">
+            <section className="relative overflow-hidden rounded-3xl bg-white/80 px-6 py-8 shadow-xl ring-1 ring-blue-100 backdrop-blur">
+              <div className="absolute -top-16 -right-10 h-40 w-40 rounded-full bg-sky-200/50 blur-3xl" aria-hidden="true"></div>
+              <div className="absolute -bottom-12 -left-10 h-36 w-36 rounded-full bg-emerald-200/60 blur-3xl" aria-hidden="true"></div>
+              <div className="relative flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <h2 className="text-2xl font-semibold text-slate-900">設定を選んで、あなただけのプリントを作成</h2>
+                  <p className="mt-2 text-sm text-slate-600 leading-relaxed">
+                    学年・計算の種類・レイアウトを組み合わせると、お子さまの学習状況にぴったりのプリントが完成します。
+                    プレビューを確認しながら、納得のいく構成に仕上げてください。
+                  </p>
+                </div>
+                <div className="flex flex-col gap-3 text-sm text-slate-600">
+                  <div className="flex items-center gap-2 rounded-full bg-sky-100/80 px-4 py-2 shadow-sm">
+                    <span className="text-lg">🧭</span>
+                    <span>ステップごとに案内するやさしいガイド</span>
+                  </div>
+                  <div className="flex items-center gap-2 rounded-full bg-emerald-100/80 px-4 py-2 shadow-sm">
+                    <span className="text-lg">⏱️</span>
+                    <span>自動生成で準備の時間を短縮</span>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
               {/* Settings Panel */}
               <div className="lg:col-span-1">
-                <div className="bg-white rounded-lg shadow p-6 sticky top-8">
-                  <h2 className="text-xl font-semibold mb-6">設定</h2>
+                <div className="sticky top-8 space-y-6 rounded-3xl bg-white/80 p-6 shadow-lg ring-1 ring-blue-100 backdrop-blur">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold text-slate-900">設定</h2>
+                    <span className="text-xs font-medium text-sky-600">STEP 1</span>
+                  </div>
 
                   {/* Problem Type Selection */}
                   <div className="mb-6">
@@ -122,7 +149,7 @@ function App(): React.ReactElement {
 
                   {isGenerating && (
                     <div className="mb-6 text-center">
-                      <div className="inline-flex items-center px-4 py-2 text-sm text-blue-600">
+                      <div className="inline-flex items-center rounded-full bg-sky-50 px-4 py-2 text-sm font-medium text-sky-600 shadow-inner">
                         <svg
                           className="animate-spin -ml-1 mr-3 h-4 w-4 text-blue-600"
                           xmlns="http://www.w3.org/2000/svg"
@@ -150,21 +177,19 @@ function App(): React.ReactElement {
 
                   {/* Export Controls */}
                   {worksheetData && (
-                    <div className="mt-6 pt-6 border-t border-gray-200">
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium text-gray-700">
+                    <div className="mt-6 rounded-2xl border border-sky-100 bg-sky-50/60 p-4">
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-sm font-semibold text-sky-900">
                           表示オプション
                         </span>
-                        <label className="flex items-center">
+                        <label className="flex items-center text-sm text-slate-600">
                           <input
                             type="checkbox"
                             checked={showAnswers}
                             onChange={(e) => setShowAnswers(e.target.checked)}
-                            className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                            className="h-4 w-4 rounded border-sky-300 text-sky-500 focus:ring-sky-400"
                           />
-                          <span className="ml-2 text-sm text-gray-600">
-                            解答表示
-                          </span>
+                          <span className="ml-2">解答表示</span>
                         </label>
                       </div>
                     </div>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -2,12 +2,65 @@ import React from 'react';
 
 export const Header: React.FC = () => {
   return (
-    <header className="bg-blue-600 text-white py-4 px-6 no-print">
-      <div className="max-w-7xl mx-auto">
-        <h1 className="text-2xl font-bold">計算プリント作成ツール</h1>
-        <p className="text-sm opacity-90 mt-1">
-          小学校の算数カリキュラムに対応した計算プリントを自動生成
-        </p>
+    <header className="relative overflow-hidden bg-gradient-to-r from-sky-500 via-blue-500 to-indigo-500 text-white no-print shadow-lg">
+      <div className="absolute -top-12 -left-10 h-48 w-48 rounded-full bg-white/20 blur-3xl" aria-hidden="true"></div>
+      <div className="absolute -bottom-16 -right-10 h-64 w-64 rounded-full bg-emerald-300/30 blur-3xl" aria-hidden="true"></div>
+
+      <div className="relative max-w-7xl mx-auto px-6 py-10">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-4">
+            <span className="inline-flex items-center px-3 py-1 text-xs font-semibold tracking-wide uppercase bg-white/20 rounded-full backdrop-blur-sm">
+              ✨ 新しいプリントづくりをもっと手軽に
+            </span>
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">
+                計算プリント作成ツール
+              </h1>
+              <p className="mt-2 text-base text-white/90 leading-relaxed">
+                学年や計算パターンを選ぶだけで、教室ですぐに使える計算プリントを生成できます。
+                先生もご家庭の方も、準備時間を短縮して学習サポートに集中しましょう。
+              </p>
+            </div>
+            <dl className="grid grid-cols-1 gap-4 text-sm text-white/90 sm:grid-cols-3">
+              <div className="flex items-start gap-2">
+                <span className="mt-0.5 text-lg">🎯</span>
+                <div>
+                  <dt className="font-semibold">学年別カリキュラム対応</dt>
+                  <dd>学習段階に合わせた問題を自動でご提案します。</dd>
+                </div>
+              </div>
+              <div className="flex items-start gap-2">
+                <span className="mt-0.5 text-lg">🖨️</span>
+                <div>
+                  <dt className="font-semibold">ワンクリック印刷</dt>
+                  <dd>PDF出力を待たずにそのままプリントできます。</dd>
+                </div>
+              </div>
+              <div className="flex items-start gap-2">
+                <span className="mt-0.5 text-lg">🌟</span>
+                <div>
+                  <dt className="font-semibold">学習を楽しく</dt>
+                  <dd>色味を抑えたやさしいUIで迷わず設定できます。</dd>
+                </div>
+              </div>
+            </dl>
+          </div>
+
+          <div className="hidden md:block">
+            <div className="relative">
+              <div className="absolute -inset-1 rounded-3xl bg-white/30 blur" aria-hidden="true"></div>
+              <div className="relative flex flex-col items-center gap-3 rounded-3xl bg-white/20 px-10 py-8 text-center backdrop-blur-lg">
+                <span className="text-5xl">📚</span>
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-white/80">
+                  Ready to print
+                </p>
+                <p className="text-sm leading-relaxed text-white/90">
+                  学校や家庭学習で使える<br />オリジナルのプリントを作成
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/src/components/Preview/WorksheetPreview.tsx
+++ b/src/components/Preview/WorksheetPreview.tsx
@@ -69,12 +69,17 @@ export const WorksheetPreview: React.FC<WorksheetPreviewProps> = ({
   );
   if (!worksheetData) {
     return (
-      <div className="bg-white border border-gray-200 rounded-lg p-8 min-h-96 flex items-center justify-center">
-        <div className="text-center text-gray-500">
-          <div className="text-6xl mb-4">📝</div>
-          <h3 className="text-lg font-medium mb-2">問題プレビューエリア</h3>
-          <p className="text-sm">
-            左側の設定で問題を生成すると、ここに問題プレビューが表示されます
+      <div className="flex min-h-96 items-center justify-center rounded-3xl border border-dashed border-sky-200/80 bg-white/70 p-8 text-sky-700 shadow-inner backdrop-blur">
+        <div className="text-center space-y-3">
+          <div className="text-6xl">📝</div>
+          <div>
+            <h3 className="text-lg font-semibold">問題プレビューエリア</h3>
+            <p className="mt-2 text-sm text-slate-600">
+              左側の設定で「生成」すると、ここに出来上がったプリントが表示されます。
+            </p>
+          </div>
+          <p className="text-xs text-slate-500">
+            学年・問題数・レイアウトを選んで、ぴったりのプリントを作りましょう。
           </p>
         </div>
       </div>
@@ -87,21 +92,21 @@ export const WorksheetPreview: React.FC<WorksheetPreviewProps> = ({
 
   return (
     <>
-      <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+      <div className="overflow-hidden rounded-3xl border border-sky-100 bg-white/85 shadow-xl backdrop-blur">
         {/* Worksheet Header */}
-        <div className="p-6 border-b border-gray-200 bg-gray-50 no-print">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-black">
+        <div className="no-print border-b border-sky-100 bg-gradient-to-r from-sky-50 via-white to-emerald-50 p-6">
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-lg font-semibold text-slate-900">
               問題プレビュー - {getPreviewTitle(settings)}
             </h2>
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-slate-500">
               {problems.length}問 • {settings.layoutColumns}列レイアウト
             </div>
           </div>
-          <div className="flex items-center space-x-4 text-sm text-gray-600">
+          <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
             <span>生成日時: {formatDate(generatedAt)}</span>
             {showAnswers && (
-              <span className="px-2 py-1 bg-red-100 text-red-800 rounded-full text-xs">
+              <span className="rounded-full bg-rose-100 px-3 py-1 text-rose-700 shadow-sm">
                 解答表示中
               </span>
             )}
@@ -141,13 +146,13 @@ export const WorksheetPreview: React.FC<WorksheetPreviewProps> = ({
         </div>
 
         {/* Print Button - Below problems */}
-        <div className="p-6 pt-0 no-print">
+        <div className="no-print p-6 pt-0">
           <button
             onClick={() => setIsMultiPageDialogOpen(true)}
-            className="w-full flex items-center justify-center px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 transition-colors"
+            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-emerald-500 px-4 py-3 text-white shadow-lg transition-colors hover:bg-emerald-600"
           >
             <svg
-              className="w-5 h-5 mr-2"
+              className="h-5 w-5"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -159,7 +164,7 @@ export const WorksheetPreview: React.FC<WorksheetPreviewProps> = ({
                 d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
               />
             </svg>
-            印刷
+            印刷（複数ページにも対応）
           </button>
         </div>
       </div>

--- a/src/components/ProblemGenerator/ProblemTypeSelector.tsx
+++ b/src/components/ProblemGenerator/ProblemTypeSelector.tsx
@@ -67,13 +67,13 @@ export const ProblemTypeSelector: React.FC<ProblemTypeSelectorProps> = ({
   return (
     <div className="space-y-6">
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
+        <label className="mb-2 block text-sm font-semibold text-slate-700">
           学年
         </label>
         <select
           value={grade}
           onChange={(e) => onGradeChange(Number(e.target.value) as Grade)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          className="w-full rounded-xl border border-sky-200 bg-white/80 px-4 py-2 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-400 focus:border-sky-300"
         >
           <option value={1}>1年生</option>
           <option value={2}>2年生</option>
@@ -96,11 +96,11 @@ export const ProblemTypeSelector: React.FC<ProblemTypeSelectorProps> = ({
       )}
 
 
-      <div className="p-4 bg-blue-50 rounded-md">
-        <h4 className="text-sm font-medium text-blue-900 mb-2">
+      <div className="rounded-2xl border border-sky-100 bg-sky-50/80 p-4">
+        <h4 className="mb-2 text-sm font-semibold text-sky-900">
           {grade}年生 {getProblemTypeDescription(problemType)}
         </h4>
-        <p className="text-sm text-blue-700">
+        <p className="text-sm text-slate-600 leading-relaxed">
           {getGradeProblemTypeDescription(grade, problemType, operation)}
         </p>
       </div>

--- a/src/components/ProblemGenerator/SettingsPanel.tsx
+++ b/src/components/ProblemGenerator/SettingsPanel.tsx
@@ -97,17 +97,17 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     <div className="space-y-6">
       {/* レイアウトを先に選択 */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
+        <label className="mb-2 block text-sm font-semibold text-slate-700">
           レイアウト
         </label>
         <div className="grid grid-cols-3 gap-2">
           <button
             type="button"
             onClick={() => onLayoutColumnsChange(1)}
-            className={`px-4 py-2 text-sm font-medium rounded-md border ${
+            className={`rounded-2xl border px-4 py-2 text-sm font-semibold transition ${
               layoutColumns === 1
-                ? 'bg-blue-600 text-white border-blue-600'
-                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                ? 'border-sky-500 bg-sky-500/90 text-white shadow'
+                : 'border-sky-200 bg-white/80 text-slate-600 hover:bg-sky-50'
             }`}
           >
             1列
@@ -115,10 +115,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           <button
             type="button"
             onClick={() => onLayoutColumnsChange(2)}
-            className={`px-4 py-2 text-sm font-medium rounded-md border ${
+            className={`rounded-2xl border px-4 py-2 text-sm font-semibold transition ${
               layoutColumns === 2
-                ? 'bg-blue-600 text-white border-blue-600'
-                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                ? 'border-sky-500 bg-sky-500/90 text-white shadow'
+                : 'border-sky-200 bg-white/80 text-slate-600 hover:bg-sky-50'
             }`}
           >
             2列
@@ -126,24 +126,24 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           <button
             type="button"
             onClick={() => onLayoutColumnsChange(3)}
-            className={`px-4 py-2 text-sm font-medium rounded-md border ${
+            className={`rounded-2xl border px-4 py-2 text-sm font-semibold transition ${
               layoutColumns === 3
-                ? 'bg-blue-600 text-white border-blue-600'
-                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                ? 'border-sky-500 bg-sky-500/90 text-white shadow'
+                : 'border-sky-200 bg-white/80 text-slate-600 hover:bg-sky-50'
             }`}
           >
             3列
           </button>
         </div>
-        <p className="text-xs text-gray-500 mt-1">
+        <p className="mt-1 text-xs text-slate-500">
           印刷時のレイアウトを選択してください
         </p>
-        <p className="text-xs text-gray-500 mt-1">
+        <p className="mt-1 text-xs text-slate-500">
           ※ {layoutColumns}列の場合、最大{maxProblems}問まで入ります
         </p>
         {isWord && (
-          <div className="mt-2 p-2 bg-blue-50 rounded-md border border-blue-200">
-            <p className="text-xs text-blue-700 font-medium mb-2">
+          <div className="mt-2 rounded-2xl border border-sky-100 bg-sky-50/70 p-3">
+            <p className="mb-2 text-xs font-semibold text-sky-800">
               💡 {template.displayName}の推奨問題数 (A4用紙1枚に最適)
             </p>
             <div className="grid grid-cols-3 gap-1">
@@ -157,12 +157,12 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                     key={cols}
                     type="button"
                     onClick={() => onProblemCountChange(colRecommended)}
-                    className={`px-2 py-1 text-xs rounded border relative ${
+                    className={`relative rounded-2xl border px-2 py-1 text-xs transition ${
                       isSelected
-                        ? 'bg-blue-600 text-white border-blue-600'
+                        ? 'border-sky-500 bg-sky-500/90 text-white shadow'
                         : isCurrentLayout
-                          ? 'bg-blue-100 text-blue-700 border-blue-400 hover:bg-blue-200 ring-2 ring-blue-300'
-                          : 'bg-white text-blue-600 border-blue-300 hover:bg-blue-50'
+                          ? 'border-sky-300 bg-sky-100/90 text-sky-700 ring-2 ring-sky-200 hover:bg-sky-200/80'
+                          : 'border-sky-200 bg-white/80 text-sky-600 hover:bg-sky-50'
                     }`}
                   >
                     {cols}列: {colRecommended}問
@@ -173,7 +173,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 );
               })}
             </div>
-            <p className="text-xs text-blue-600 mt-1">
+            <p className="mt-1 text-xs text-sky-700">
               🎯 現在のレイアウト({layoutColumns}列)の推奨: {recommendedCount}問
             </p>
           </div>
@@ -181,13 +181,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
+        <label className="mb-2 block text-sm font-semibold text-slate-700">
           問題数
         </label>
 
         {/* クイック選択ボタン */}
-        <div className="mb-3 p-3 bg-gray-50 rounded-lg border border-gray-200">
-          <p className="text-xs text-gray-600 mb-2 font-medium">
+        <div className="mb-3 rounded-2xl border border-sky-100 bg-slate-50/80 p-3">
+          <p className="mb-2 text-xs font-semibold text-slate-600">
             クイック選択
           </p>
           <div className="grid grid-cols-3 gap-2">
@@ -196,10 +196,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
               <button
                 type="button"
                 onClick={() => onProblemCountChange(lessCount)}
-                className={`px-3 py-2 text-sm rounded-md border transition-colors ${
+                className={`rounded-2xl border px-3 py-2 text-sm font-medium transition ${
                   problemCount === lessCount
-                    ? 'bg-blue-600 text-white border-blue-600'
-                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-100'
+                    ? 'border-sky-500 bg-sky-500/90 text-white shadow'
+                    : 'border-sky-200 bg-white/80 text-slate-600 hover:bg-sky-50'
                 }`}
               >
                 少なめ<br />
@@ -211,10 +211,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
             <button
               type="button"
               onClick={() => onProblemCountChange(recommendedCount)}
-              className={`px-3 py-2 text-sm rounded-md border transition-colors ${
+              className={`rounded-2xl border px-3 py-2 text-sm font-medium transition ${
                 problemCount === recommendedCount
-                  ? 'bg-blue-600 text-white border-blue-600'
-                  : 'bg-blue-50 text-blue-700 border-blue-300 hover:bg-blue-100'
+                  ? 'border-sky-500 bg-sky-500/90 text-white shadow'
+                  : 'border-sky-200 bg-sky-50/80 text-sky-700 hover:bg-sky-100'
               }`}
             >
               推奨 🎯<br />
@@ -226,10 +226,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
               <button
                 type="button"
                 onClick={() => onProblemCountChange(moreCount)}
-                className={`px-3 py-2 text-sm rounded-md border transition-colors ${
+                className={`rounded-2xl border px-3 py-2 text-sm font-medium transition ${
                   problemCount === moreCount
-                    ? 'bg-blue-600 text-white border-blue-600'
-                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-100'
+                    ? 'border-sky-500 bg-sky-500/90 text-white shadow'
+                    : 'border-sky-200 bg-white/80 text-slate-600 hover:bg-sky-50'
                 }`}
               >
                 多め<br />
@@ -241,13 +241,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
 
         {/* 詳細選択 */}
         <div>
-          <label className="block text-xs text-gray-600 mb-1">
+          <label className="mb-1 block text-xs font-medium text-slate-500">
             詳細選択 ({minProblems}〜{maxProblems}問、{step}問ステップ)
           </label>
           <select
             value={problemCount}
             onChange={(e) => onProblemCountChange(Number(e.target.value))}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full rounded-2xl border border-sky-200 bg-white/80 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-400 focus:border-sky-300"
           >
             {problemCountOptions.map((count) => (
               <option key={count} value={count}>

--- a/src/index.css
+++ b/src/index.css
@@ -21,7 +21,7 @@
   }
 
   body {
-    @apply text-black bg-white;
+    @apply text-gray-900 bg-gradient-to-br from-sky-50 via-white to-emerald-50 antialiased;
   }
 
   /* 筆算（縦書き計算）のスタイル */


### PR DESCRIPTION
## Summary
- update the app background and header hero with gradients and friendlier messaging
- restyle the settings and preview panels with softer cards and an improved empty state
- refresh selector and button styling for a more approachable configuration experience

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_69085406ce2c8326803def0a0b439d30