### PR TITLE
chore: Playwright MCPを復活させ playwright-cli の使い分けを整理する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,16 +87,16 @@ const template = getPrintTemplate(effectiveType);
 
 印刷レイアウトの確認に2つのツールを使い分ける。
 
-| ツール                     | 用途                                       | 設定                   |
-| -------------------------- | ------------------------------------------ | ---------------------- |
-| **Playwright MCP**         | 開発中のUI確認・インタラクティブなデバッグ | `.mcp.json`            |
-| **check-print-layout.mjs** | CI/ローカルでの自動レイアウトチェック      | `npm run check:layout` |
+| ツール                     | 用途                                       | 設定                             |
+| -------------------------- | ------------------------------------------ | -------------------------------- |
+| **Playwright MCP**         | 開発中のUI確認・インタラクティブなデバッグ | `.mcp.json`                      |
+| **check-print-layout.mjs** | CI/ローカルでの自動レイアウトチェック      | `scripts/check-print-layout.mjs` |
 
 ### Playwright MCP（インタラクティブ確認）
 
 `.mcp.json` で設定済み。Claude Code から直接ブラウザを操作できる。
 
-```
+```text
 # ページを開く
 mcp__playwright__browser_navigate → url: "https://knishioka.github.io/math-worksheet/"
 


### PR DESCRIPTION
## Summary

- Playwright MCP は `.mcp.json` に既に設定済みであることを確認
- `scripts/check-print-layout.mjs` は CI/ローカル向け自動チェックとして維持
- CLAUDE.md の「Playwright CLIによるレイアウト確認」セクションを「レイアウト確認」に改名し、2ツールの使い分けを明記

### ツール使い分け

| ツール | 用途 |
|--------|------|
| **Playwright MCP** | 開発中のUI確認・インタラクティブなデバッグ |
| **check-print-layout.mjs** | CI/CDでのheadlessレイアウトチェック (`npm run check:layout`) |

## Test plan

- [x] `npm run lint` pass
- [x] `npm run typecheck` pass
- [x] `npm test -- --run` pass (484 tests)
- [x] `npm run build` pass

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)