### PR TITLE
fix: 1年生+1/+2たし算の2列レイアウトで列ごとに問題が重複するバグを修正

### DIFF
--- a/src/lib/generators/patterns/grade1-beginner.test.ts
+++ b/src/lib/generators/patterns/grade1-beginner.test.ts
@@ -49,8 +49,7 @@ describe('generateAddPlusOne (+1のたし算)', () => {
       const secondHalf = problems.slice(10, 20).map((p) => p.operand1);
 
       // 前半10問と後半10問が完全一致しないこと
-      const isIdentical = firstHalf.every((v, i) => v === secondHalf[i]);
-      expect(isIdentical).toBe(false);
+      expect(firstHalf).not.toEqual(secondHalf);
     }
   });
 });
@@ -86,8 +85,7 @@ describe('generateAddPlusTwo (+2のたし算)', () => {
       const firstHalf = problems.slice(0, 9).map((p) => p.operand1);
       const secondHalf = problems.slice(9, 18).map((p) => p.operand1);
 
-      const isIdentical = firstHalf.every((v, i) => v === secondHalf[i]);
-      expect(isIdentical).toBe(false);
+      expect(firstHalf).not.toEqual(secondHalf);
     }
   });
 });

--- a/src/lib/generators/patterns/grade1-beginner.test.ts
+++ b/src/lib/generators/patterns/grade1-beginner.test.ts
@@ -38,6 +38,21 @@ describe('generateAddPlusOne (+1のたし算)', () => {
     const unique = new Set(operands);
     expect(unique.size).toBe(10); // 0-9 は10通りなので全てユニーク
   });
+
+  it('should not have structurally identical halves when count exceeds pool size (2列20問)', () => {
+    // 複数回テストして確率的に検証
+    for (let trial = 0; trial < 5; trial++) {
+      const problems = generateAddPlusOne(baseSettings, 20);
+      expect(problems).toHaveLength(20);
+
+      const firstHalf = problems.slice(0, 10).map((p) => p.operand1);
+      const secondHalf = problems.slice(10, 20).map((p) => p.operand1);
+
+      // 前半10問と後半10問が完全一致しないこと
+      const isIdentical = firstHalf.every((v, i) => v === secondHalf[i]);
+      expect(isIdentical).toBe(false);
+    }
+  });
 });
 
 describe('generateAddPlusTwo (+2のたし算)', () => {
@@ -61,6 +76,19 @@ describe('generateAddPlusTwo (+2のたし算)', () => {
     const operands = problems.map((p) => p.operand1);
     const unique = new Set(operands);
     expect(unique.size).toBe(9); // 0-8 は9通りなので全てユニーク
+  });
+
+  it('should not have structurally identical halves when count exceeds pool size (2列20問)', () => {
+    for (let trial = 0; trial < 5; trial++) {
+      const problems = generateAddPlusTwo(baseSettings, 20);
+      expect(problems).toHaveLength(20);
+
+      const firstHalf = problems.slice(0, 9).map((p) => p.operand1);
+      const secondHalf = problems.slice(9, 18).map((p) => p.operand1);
+
+      const isIdentical = firstHalf.every((v, i) => v === secondHalf[i]);
+      expect(isIdentical).toBe(false);
+    }
   });
 });
 

--- a/src/lib/generators/patterns/grade1.ts
+++ b/src/lib/generators/patterns/grade1.ts
@@ -6,7 +6,7 @@ import type {
 import { generateId, randomInt } from '../../utils/math';
 
 // Fisher-Yatesシャッフル
-function shuffleArray(arr: number[]): void {
+function shuffleArray<T>(arr: T[]): void {
   for (let i = arr.length - 1; i > 0; i--) {
     const j = randomInt(0, i);
     [arr[i], arr[j]] = [arr[j], arr[i]];
@@ -322,12 +322,13 @@ export function generateAddTo10(
   ];
 
   // ペアをシャッフル
-  const shuffledPairs = [...pairs].sort(() => Math.random() - 0.5);
+  const shuffledPairs = [...pairs];
+  shuffleArray(shuffledPairs);
 
   for (let i = 0; i < count; i++) {
     // プールを使い切ったら再シャッフルして構造的重複を防ぐ
     if (i > 0 && i % shuffledPairs.length === 0) {
-      shuffledPairs.sort(() => Math.random() - 0.5);
+      shuffleArray(shuffledPairs);
     }
     const pair = shuffledPairs[i % shuffledPairs.length];
     const [operand1, operand2] =

--- a/src/lib/generators/patterns/grade1.ts
+++ b/src/lib/generators/patterns/grade1.ts
@@ -5,6 +5,14 @@ import type {
 } from '../../../types';
 import { generateId, randomInt } from '../../utils/math';
 
+// Fisher-Yatesシャッフル
+function shuffleArray(arr: number[]): void {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = randomInt(0, i);
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
 // 1年生（入門）: +N のたし算（共通関数）
 function generateAddPlusN(
   count: number,
@@ -14,13 +22,14 @@ function generateAddPlusN(
   // シャッフルプールで重複なしを保証
   const pool: number[] = [];
   for (let i = 0; i <= maxOperand1; i++) pool.push(i);
-  for (let i = pool.length - 1; i > 0; i--) {
-    const j = randomInt(0, i);
-    [pool[i], pool[j]] = [pool[j], pool[i]];
-  }
+  shuffleArray(pool);
 
   const problems: BasicProblem[] = [];
   for (let i = 0; i < count; i++) {
+    // プールを使い切ったら再シャッフルして構造的重複を防ぐ
+    if (i > 0 && i % pool.length === 0) {
+      shuffleArray(pool);
+    }
     const operand1 = pool[i % pool.length];
     problems.push({
       id: generateId(),
@@ -316,6 +325,10 @@ export function generateAddTo10(
   const shuffledPairs = [...pairs].sort(() => Math.random() - 0.5);
 
   for (let i = 0; i < count; i++) {
+    // プールを使い切ったら再シャッフルして構造的重複を防ぐ
+    if (i > 0 && i % shuffledPairs.length === 0) {
+      shuffledPairs.sort(() => Math.random() - 0.5);
+    }
     const pair = shuffledPairs[i % shuffledPairs.length];
     const [operand1, operand2] =
       Math.random() < 0.5 ? pair : [pair[1], pair[0]];


### PR DESCRIPTION
## Summary
- `generateAddPlusN`で問題数がプール（0〜9の10通り）を超えた場合、同じシャッフル順で巡回するため2列目が1列目の丸コピーになっていたバグを修正
- プール使い切り時に再シャッフルすることで、列ごとの構造的重複を防止
- 同じパターンを持つ`generateAddTo10`も併せて修正

## Changes
- `src/lib/generators/patterns/grade1.ts`: プール巡回時の再シャッフルロジック追加
- `src/lib/generators/patterns/grade1-beginner.test.ts`: 2列20問で前半・後半が完全一致しないことを検証するテスト追加（+1, +2両方）

## Root Cause
`pool[i % pool.length]` でプールサイズを超えた場合、モジュロにより先頭から同一順序で再利用されていた。2列レイアウトでは問題1-10が列1、11-20が列2に分割されるため、完全に同じ問題セットが表示されていた。

## Test plan
- [x] `npm run lint` pass
- [x] `npm run typecheck` pass
- [x] `npm test -- --run` 488 tests pass
- [x] `npm run build` pass
- [x] 新テスト: +1/+2で20問生成時、前半10問と後半10問が完全一致しないことを5回試行で検証

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)