### PR TITLE
feat: Add automated verification layer for math problem generators

### DIFF
--- a/docs/testing/playwright-mcp-verification.md
+++ b/docs/testing/playwright-mcp-verification.md
@@ -95,7 +95,7 @@ For batch verification without interactive inspection:
 
 ```bash
 # All patterns (local dev server)
-npm run verify:playwright
+npm run verify:playwright:dev
 
 # Singapore patterns only (faster)
 npm run verify:singapore
@@ -103,9 +103,11 @@ npm run verify:singapore
 # Specific pattern
 node scripts/verify-playwright.mjs --pattern=word-en
 
-# Against production build
-npm run build && npm run preview &
-npm run verify:playwright:local
+# Against production build (run in separate terminals)
+# Terminal 1:
+npm run build && npm run preview
+# Terminal 2:
+npm run verify:playwright:preview
 ```
 
 The script captures screenshots to `artifacts/playwright-verify/` and validates:

--- a/docs/testing/playwright-mcp-verification.md
+++ b/docs/testing/playwright-mcp-verification.md
@@ -1,0 +1,136 @@
+# Playwright MCP Integration for AI-Assisted Verification
+
+How to use Playwright MCP with Claude Code (or other AI coding agents) for interactive visual verification of math worksheet problems.
+
+## Overview
+
+The verification loop:
+
+1. **Generate** - AI agent implements or modifies a problem generator
+2. **Render** - AI navigates to the app via Playwright MCP, selects the pattern
+3. **Screenshot** - AI captures the rendered output
+4. **Review** - AI analyzes the screenshot for visual correctness
+5. **Fix** - AI fixes any issues found and repeats
+
+This replaces manual browser inspection and catches bugs like self-referential names, incorrect answers, and grade-level mismatches.
+
+## Prerequisites
+
+- Playwright MCP configured in `.mcp.json` (already set up in this project)
+- Development server running: `npm run dev`
+
+## Interactive Verification with Playwright MCP
+
+### Step 1: Navigate to the app
+
+```
+mcp__playwright__browser_navigate → url: "http://localhost:5174/"
+```
+
+### Step 2: Inspect available controls
+
+```
+mcp__playwright__browser_snapshot
+```
+
+This returns the accessibility tree with element refs (e.g., `e5` for grade selector, `e10` for pattern radio buttons).
+
+### Step 3: Select grade and pattern
+
+```
+# Select grade 3
+mcp__playwright__browser_select_option → ref: "<grade-select-ref>", values: ["3"]
+
+# Click a pattern radio button
+mcp__playwright__browser_click → ref: "<pattern-radio-ref>"
+```
+
+### Step 4: Verify rendered problems
+
+```
+# Take a screenshot
+mcp__playwright__browser_take_screenshot
+
+# Or inspect the DOM
+mcp__playwright__browser_snapshot
+```
+
+### Step 5: Toggle answer visibility
+
+```
+# Find the answer toggle checkbox
+mcp__playwright__browser_snapshot
+
+# Click to show/hide answers
+mcp__playwright__browser_click → ref: "<answer-toggle-ref>"
+
+# Screenshot with answers visible
+mcp__playwright__browser_take_screenshot
+```
+
+## What to Check
+
+### For all problem types
+
+- Problems render (no blank screen)
+- Problem text is non-empty and readable
+- Answer toggle works (shows/hides answers)
+
+### For Singapore Math problems
+
+- **Name uniqueness**: No "Noah has 4 more than Noah" (self-referential)
+- **Grade constraints**: Grade 2 comparison uses "more/fewer", Grade 3+ uses "times as many"
+- **Diagram correctness**: Bar models show segments, number bonds show parts
+- **Answer math**: Multi-step fraction answers match reverse calculation
+
+### For word problems
+
+- Problem text is grammatically correct English
+- Numbers in the problem are appropriate for the grade level
+- Answer makes sense in context
+
+## Automated Verification Script
+
+For batch verification without interactive inspection:
+
+```bash
+# All patterns (local dev server)
+npm run verify:playwright
+
+# Singapore patterns only (faster)
+npm run verify:singapore
+
+# Specific pattern
+node scripts/verify-playwright.mjs --pattern=word-en
+
+# Against production build
+npm run build && npm run preview &
+npm run verify:playwright:local
+```
+
+The script captures screenshots to `artifacts/playwright-verify/` and validates:
+
+- Problems render for each grade/pattern combo
+- No self-referential names
+- Grade-appropriate comparison language
+- Multi-step answer correctness
+
+## Runtime Assertions
+
+The generators also include runtime assertions (`src/lib/generators/assertions.ts`) that catch issues at generation time:
+
+- `assertValidAnswer` - Answer must be a finite positive number
+- `assertNoDuplicateNames` - No self-referential names in problem text
+- `assertNonEmptyText` - Problem text must not be empty
+
+These assertions throw immediately during generation, preventing malformed problems from reaching the UI.
+
+## Property-Based Tests
+
+Run `npm test -- --run src/lib/generators/property-tests.test.ts` for comprehensive property-based testing:
+
+- 200+ samples per generator/grade combination
+- Name uniqueness across all two-person problems
+- Mathematical correctness (reverse-calculated from problem text)
+- Grade-level constraint verification
+- Diagram math consistency (parts sum = whole, etc.)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "deploy": "npm run build && gh-pages -d dist",
     "check:layout": "node scripts/check-print-layout.mjs",
     "check:layout:local": "node scripts/check-print-layout.mjs http://localhost:4173/",
-    "verify:playwright": "node scripts/verify-playwright.mjs",
-    "verify:playwright:local": "node scripts/verify-playwright.mjs http://localhost:4173/",
+    "verify:playwright:dev": "node scripts/verify-playwright.mjs",
+    "verify:playwright:preview": "node scripts/verify-playwright.mjs http://localhost:4173/",
     "verify:singapore": "node scripts/verify-playwright.mjs --singapore-only"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "preview": "vite preview",
     "deploy": "npm run build && gh-pages -d dist",
     "check:layout": "node scripts/check-print-layout.mjs",
-    "check:layout:local": "node scripts/check-print-layout.mjs http://localhost:4173/"
+    "check:layout:local": "node scripts/check-print-layout.mjs http://localhost:4173/",
+    "verify:playwright": "node scripts/verify-playwright.mjs",
+    "verify:playwright:local": "node scripts/verify-playwright.mjs http://localhost:4173/",
+    "verify:singapore": "node scripts/verify-playwright.mjs --singapore-only"
   },
   "dependencies": {
     "pdfmake": "^0.2.20",

--- a/scripts/verify-playwright.mjs
+++ b/scripts/verify-playwright.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+/**
+ * Extended Playwright verification script for ALL problem types.
+ * Extends the original Singapore-only script to cover every pattern/grade combo.
+ *
+ * Usage:
+ *   node scripts/verify-playwright.mjs [BASE_URL]
+ *   node scripts/verify-playwright.mjs http://127.0.0.1:5173/
+ *
+ * Options:
+ *   --singapore-only   Only check Singapore Math patterns (fast mode)
+ *   --pattern=<name>   Only check a specific pattern (e.g. --pattern=word-en)
+ *
+ * Screenshots are saved to artifacts/playwright-verify/
+ * NOT run in CI - local only, triggered manually or by AI agent before push.
+ */
+
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { chromium } from '@playwright/test';
+
+const BASE_URL =
+  process.argv.find(
+    (a) => !a.startsWith('--') && a !== process.argv[0] && a !== process.argv[1]
+  ) ?? 'http://127.0.0.1:5173/';
+const OUTPUT_DIR = join(process.cwd(), 'artifacts', 'playwright-verify');
+const SINGAPORE_ONLY = process.argv.includes('--singapore-only');
+const PATTERN_FILTER = process.argv
+  .find((a) => a.startsWith('--pattern='))
+  ?.split('=')[1];
+
+// ─── Combo definitions ───────────────────────────────────────────────
+
+const SINGAPORE_COMBOS = [
+  { grade: 1, pattern: 'singapore-bar-model', slug: 'grade1-bar-model' },
+  { grade: 1, pattern: 'singapore-number-bond', slug: 'grade1-number-bond' },
+  { grade: 2, pattern: 'singapore-bar-model', slug: 'grade2-bar-model' },
+  { grade: 2, pattern: 'singapore-number-bond', slug: 'grade2-number-bond' },
+  { grade: 2, pattern: 'singapore-comparison', slug: 'grade2-comparison' },
+  { grade: 3, pattern: 'singapore-bar-model', slug: 'grade3-bar-model' },
+  { grade: 3, pattern: 'singapore-number-bond', slug: 'grade3-number-bond' },
+  { grade: 3, pattern: 'singapore-comparison', slug: 'grade3-comparison' },
+  { grade: 3, pattern: 'singapore-multi-step', slug: 'grade3-multi-step' },
+  { grade: 4, pattern: 'singapore-bar-model', slug: 'grade4-bar-model' },
+  { grade: 4, pattern: 'singapore-number-bond', slug: 'grade4-number-bond' },
+  { grade: 4, pattern: 'singapore-comparison', slug: 'grade4-comparison' },
+  { grade: 4, pattern: 'singapore-multi-step', slug: 'grade4-multi-step' },
+  { grade: 5, pattern: 'singapore-bar-model', slug: 'grade5-bar-model' },
+  { grade: 5, pattern: 'singapore-number-bond', slug: 'grade5-number-bond' },
+  { grade: 5, pattern: 'singapore-comparison', slug: 'grade5-comparison' },
+  { grade: 5, pattern: 'singapore-multi-step', slug: 'grade5-multi-step' },
+  { grade: 6, pattern: 'singapore-bar-model', slug: 'grade6-bar-model' },
+  { grade: 6, pattern: 'singapore-number-bond', slug: 'grade6-number-bond' },
+  { grade: 6, pattern: 'singapore-comparison', slug: 'grade6-comparison' },
+  { grade: 6, pattern: 'singapore-multi-step', slug: 'grade6-multi-step' },
+];
+
+const ENGLISH_WORD_COMBOS = [
+  { grade: 1, pattern: 'word-en', slug: 'grade1-word-en' },
+  { grade: 2, pattern: 'word-en', slug: 'grade2-word-en' },
+  { grade: 3, pattern: 'word-en', slug: 'grade3-word-en' },
+  { grade: 4, pattern: 'word-en', slug: 'grade4-word-en' },
+  { grade: 5, pattern: 'word-en', slug: 'grade5-word-en' },
+  { grade: 6, pattern: 'word-en', slug: 'grade6-word-en' },
+];
+
+// Representative English pattern combos (grade 3 has the widest coverage)
+const ENGLISH_PATTERN_COMBOS = [
+  { grade: 2, pattern: 'money-change-en', slug: 'grade2-money-change-en' },
+  { grade: 2, pattern: 'time-reading-en', slug: 'grade2-time-reading-en' },
+  { grade: 2, pattern: 'calendar-days-en', slug: 'grade2-calendar-days-en' },
+  { grade: 3, pattern: 'money-payment-en', slug: 'grade3-money-payment-en' },
+  { grade: 3, pattern: 'time-calc-en', slug: 'grade3-time-calc-en' },
+  { grade: 3, pattern: 'unit-length-en', slug: 'grade3-unit-length-en' },
+  {
+    grade: 3,
+    pattern: 'shopping-discount-en',
+    slug: 'grade3-shopping-discount-en',
+  },
+  {
+    grade: 3,
+    pattern: 'temperature-diff-en',
+    slug: 'grade3-temperature-diff-en',
+  },
+  { grade: 3, pattern: 'distance-walk-en', slug: 'grade3-distance-walk-en' },
+  {
+    grade: 3,
+    pattern: 'cooking-ingredients-en',
+    slug: 'grade3-cooking-ingredients-en',
+  },
+  { grade: 4, pattern: 'energy-usage-en', slug: 'grade4-energy-usage-en' },
+  { grade: 3, pattern: 'transport-fare-en', slug: 'grade3-transport-fare-en' },
+  {
+    grade: 2,
+    pattern: 'allowance-saving-en',
+    slug: 'grade2-allowance-saving-en',
+  },
+];
+
+// Basic math combos (representative samples)
+const BASIC_MATH_COMBOS = [
+  { grade: 1, pattern: 'add-single-digit', slug: 'grade1-add-single' },
+  { grade: 1, pattern: 'sub-single-digit', slug: 'grade1-sub-single' },
+  { grade: 2, pattern: 'mult-single-digit', slug: 'grade2-mult-single' },
+  { grade: 2, pattern: 'hissan-add-double', slug: 'grade2-hissan-add' },
+  { grade: 3, pattern: 'div-basic', slug: 'grade3-div-basic' },
+  { grade: 3, pattern: 'frac-same-denom', slug: 'grade3-frac-same' },
+  { grade: 3, pattern: 'add-dec-simple', slug: 'grade3-dec-add' },
+  { grade: 4, pattern: 'hissan-div-basic', slug: 'grade4-hissan-div' },
+  { grade: 5, pattern: 'frac-different-denom', slug: 'grade5-frac-diff' },
+  { grade: 6, pattern: 'frac-mult', slug: 'grade6-frac-mult' },
+];
+
+// Anzan combos
+const ANZAN_COMBOS = [
+  { grade: 1, pattern: 'anzan-complement-10', slug: 'grade1-anzan-comp10' },
+  { grade: 3, pattern: 'anzan-mul-5', slug: 'grade3-anzan-mul5' },
+  { grade: 3, pattern: 'anzan-mul-9', slug: 'grade3-anzan-mul9' },
+  { grade: 4, pattern: 'anzan-mul-11', slug: 'grade4-anzan-mul11' },
+];
+
+// ─── Validators ──────────────────────────────────────────────────────
+
+const SELF_REFERENCE_RE =
+  /\b([A-Z][a-z]+)\b has \d+[^.]*?(?:more than|fewer than|times as many as) \1\b/;
+
+const PROBLEM_SELECTOR = '[data-problem-grid] .problem-item';
+
+function normalizeText(value) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function validateRenderedProblems(combo, renderedProblems) {
+  if (renderedProblems.length === 0) {
+    throw new Error(`No problems rendered for ${combo.slug}`);
+  }
+
+  renderedProblems.forEach((text) => {
+    if (SELF_REFERENCE_RE.test(text)) {
+      throw new Error(
+        `Self-referential name found for ${combo.slug}: "${text}"`
+      );
+    }
+  });
+
+  // Singapore-specific validations
+  if (combo.pattern === 'singapore-comparison' && combo.grade === 2) {
+    renderedProblems.forEach((text) => {
+      if (text.includes('times as many')) {
+        throw new Error(
+          `Grade 2 comparison used multiplicative phrasing in ${combo.slug}: "${text}"`
+        );
+      }
+    });
+  }
+
+  if (combo.pattern === 'singapore-comparison' && combo.grade >= 3) {
+    renderedProblems.forEach((text) => {
+      if (!text.includes('times as many')) {
+        throw new Error(
+          `Grade 3+ comparison missed multiplicative phrasing in ${combo.slug}: "${text}"`
+        );
+      }
+    });
+  }
+}
+
+function validateMultiStepAnswer(renderedProblem, combo) {
+  if (combo.pattern !== 'singapore-multi-step') {
+    return;
+  }
+
+  const answerMatch = renderedProblem.match(/Answer:\s*([0-9]+(?:\.[0-9]+)?)/);
+  const totalMatch = renderedProblem.match(/(?:has|are) (\d+) /);
+  const fractions = [...renderedProblem.matchAll(/(\d+)\/(\d+)/g)];
+  if (!answerMatch || !totalMatch || fractions.length < 2) {
+    throw new Error(
+      `Could not parse multi-step problem in ${combo.slug}: "${renderedProblem}"`
+    );
+  }
+
+  const answer = Number(answerMatch[1]);
+  const total = Number(totalMatch[1]);
+  const numerator1 = Number(fractions[0][1]);
+  const denominator1 = Number(fractions[0][2]);
+  const numerator2 = Number(fractions[1][1]);
+  const denominator2 = Number(fractions[1][2]);
+
+  const usedFirst = (total * numerator1) / denominator1;
+  const remainingAfterFirst = total - usedFirst;
+  const usedSecond = (remainingAfterFirst * numerator2) / denominator2;
+  const remainingAfterSecond = remainingAfterFirst - usedSecond;
+
+  let expectedAnswer = remainingAfterSecond;
+  if (renderedProblem.includes('shared equally among')) {
+    const groupsMatch = renderedProblem.match(/among (\d+) students/);
+    if (!groupsMatch) {
+      throw new Error(
+        `Could not parse group count in ${combo.slug}: "${renderedProblem}"`
+      );
+    }
+    const groups = Number(groupsMatch[1]);
+    expectedAnswer = remainingAfterSecond / groups;
+  }
+
+  if (
+    !Number.isFinite(expectedAnswer) ||
+    Math.abs(answer - expectedAnswer) > 1e-9
+  ) {
+    throw new Error(
+      `Multi-step answer mismatch in ${combo.slug}: expected ${expectedAnswer}, got ${answer}, text="${renderedProblem}"`
+    );
+  }
+}
+
+// ─── Capture & verify ────────────────────────────────────────────────
+
+async function captureCombo(page, combo) {
+  await page.goto(BASE_URL, { waitUntil: 'networkidle' });
+  await page.selectOption('select', String(combo.grade));
+  await page.waitForTimeout(200);
+  await page.evaluate((pattern) => {
+    const input = document.querySelector(
+      `input[name="calculationPattern"][value="${pattern}"]`
+    );
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error(`Pattern input not found: ${pattern}`);
+    }
+    input.click();
+  }, combo.pattern);
+
+  await page
+    .locator('[data-a4-sheet]')
+    .waitFor({ state: 'visible', timeout: 10000 });
+
+  // Wait for problems to render
+  const firstProblemLocator = page.locator(PROBLEM_SELECTOR).first();
+  await firstProblemLocator.waitFor({ state: 'visible', timeout: 10000 });
+  await page.waitForTimeout(250);
+
+  const problemLocator = page.locator(PROBLEM_SELECTOR);
+  const count = await problemLocator.count();
+
+  if (count === 0) {
+    throw new Error(`No problems rendered for ${combo.slug}`);
+  }
+
+  const renderedOff = (await problemLocator.allInnerTexts()).map(normalizeText);
+  validateRenderedProblems(combo, renderedOff);
+
+  // Screenshot with answers off
+  const answerToggle = page.getByLabel('解答表示');
+  if (await answerToggle.isChecked()) {
+    await answerToggle.uncheck({ force: true });
+  }
+  await page.waitForTimeout(150);
+  await page.screenshot({
+    path: join(OUTPUT_DIR, `${combo.slug}-answers-off.png`),
+    fullPage: true,
+  });
+
+  // Screenshot with answers on
+  await answerToggle.check({ force: true });
+  await page.waitForTimeout(200);
+  const renderedOn = (await problemLocator.allInnerTexts()).map(normalizeText);
+
+  // Validate multi-step answers when answers are visible
+  renderedOn.forEach((text) => validateMultiStepAnswer(text, combo));
+
+  await page.screenshot({
+    path: join(OUTPUT_DIR, `${combo.slug}-answers-on.png`),
+    fullPage: true,
+  });
+}
+
+// ─── Main ────────────────────────────────────────────────────────────
+
+async function run() {
+  let combos;
+  if (SINGAPORE_ONLY) {
+    combos = SINGAPORE_COMBOS;
+    console.log('Running Singapore Math patterns only');
+  } else if (PATTERN_FILTER) {
+    combos = [
+      ...SINGAPORE_COMBOS,
+      ...ENGLISH_WORD_COMBOS,
+      ...ENGLISH_PATTERN_COMBOS,
+      ...BASIC_MATH_COMBOS,
+      ...ANZAN_COMBOS,
+    ].filter((c) => c.pattern === PATTERN_FILTER);
+    console.log(
+      `Filtered to pattern: ${PATTERN_FILTER} (${combos.length} combos)`
+    );
+  } else {
+    combos = [
+      ...SINGAPORE_COMBOS,
+      ...ENGLISH_WORD_COMBOS,
+      ...ENGLISH_PATTERN_COMBOS,
+      ...BASIC_MATH_COMBOS,
+      ...ANZAN_COMBOS,
+    ];
+    console.log(`Running ALL patterns (${combos.length} combos)`);
+  }
+
+  if (combos.length === 0) {
+    console.error('No matching combos found');
+    process.exitCode = 1;
+    return;
+  }
+
+  await rm(OUTPUT_DIR, { recursive: true, force: true });
+  await mkdir(OUTPUT_DIR, { recursive: true });
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 1600, height: 1200 },
+  });
+  const page = await context.newPage();
+
+  const startTime = Date.now();
+  let passed = 0;
+  let failed = 0;
+
+  try {
+    for (const combo of combos) {
+      try {
+        process.stdout.write(`  ${combo.slug} ... `);
+        await captureCombo(page, combo);
+        console.log('OK');
+        passed++;
+      } catch (err) {
+        console.log(`FAIL: ${err.message}`);
+        failed++;
+      }
+    }
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log(`\nDone in ${elapsed}s: ${passed} passed, ${failed} failed`);
+    console.log(`Screenshots: ${OUTPUT_DIR}`);
+
+    if (failed > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/verify-playwright.mjs
+++ b/scripts/verify-playwright.mjs
@@ -172,11 +172,21 @@ function validateMultiStepAnswer(renderedProblem, combo) {
   }
 
   const answerMatch = renderedProblem.match(/Answer:\s*([0-9]+(?:\.[0-9]+)?)/);
-  const totalMatch = renderedProblem.match(/(?:has|are) (\d+) /);
-  const fractions = [...renderedProblem.matchAll(/(\d+)\/(\d+)/g)];
-  if (!answerMatch || !totalMatch || fractions.length < 2) {
+  if (!answerMatch) {
     throw new Error(
-      `Could not parse multi-step problem in ${combo.slug}: "${renderedProblem}"`
+      `Could not find answer in multi-step problem in ${combo.slug}: "${renderedProblem}"`
+    );
+  }
+  const totalMatch = renderedProblem.match(/(?:has|are) (\d+) /);
+  if (!totalMatch) {
+    throw new Error(
+      `Could not find total value in multi-step problem in ${combo.slug}: "${renderedProblem}"`
+    );
+  }
+  const fractions = [...renderedProblem.matchAll(/(\d+)\/(\d+)/g)];
+  if (fractions.length < 2) {
+    throw new Error(
+      `Expected at least 2 fractions but found ${fractions.length} in ${combo.slug}: "${renderedProblem}"`
     );
   }
 
@@ -219,7 +229,10 @@ function validateMultiStepAnswer(renderedProblem, combo) {
 async function captureCombo(page, combo) {
   await page.goto(BASE_URL, { waitUntil: 'networkidle' });
   await page.selectOption('select', String(combo.grade));
-  await page.waitForTimeout(200);
+  // Wait for grade selection to take effect
+  await page
+    .locator('[data-a4-sheet]')
+    .waitFor({ state: 'visible', timeout: 5000 });
   await page.evaluate((pattern) => {
     const input = document.querySelector(
       `input[name="calculationPattern"][value="${pattern}"]`
@@ -234,10 +247,21 @@ async function captureCombo(page, combo) {
     .locator('[data-a4-sheet]')
     .waitFor({ state: 'visible', timeout: 10000 });
 
-  // Wait for problems to render
+  // Wait for problems to render by checking for visible problem items
   const firstProblemLocator = page.locator(PROBLEM_SELECTOR).first();
   await firstProblemLocator.waitFor({ state: 'visible', timeout: 10000 });
-  await page.waitForTimeout(250);
+  // Wait until problem count stabilizes (all problems rendered)
+  await page.waitForFunction(
+    (selector) => {
+      const items = document.querySelectorAll(selector);
+      return (
+        items.length > 0 &&
+        [...items].every((el) => el.textContent?.trim().length > 0)
+      );
+    },
+    PROBLEM_SELECTOR,
+    { timeout: 10000 }
+  );
 
   const problemLocator = page.locator(PROBLEM_SELECTOR);
   const count = await problemLocator.count();
@@ -253,8 +277,15 @@ async function captureCombo(page, combo) {
   const answerToggle = page.getByLabel('解答表示');
   if (await answerToggle.isChecked()) {
     await answerToggle.uncheck({ force: true });
+    await page.waitForFunction(
+      (selector) => {
+        const items = document.querySelectorAll(selector);
+        return items.length > 0;
+      },
+      PROBLEM_SELECTOR,
+      { timeout: 5000 }
+    );
   }
-  await page.waitForTimeout(150);
   await page.screenshot({
     path: join(OUTPUT_DIR, `${combo.slug}-answers-off.png`),
     fullPage: true,
@@ -262,7 +293,18 @@ async function captureCombo(page, combo) {
 
   // Screenshot with answers on
   await answerToggle.check({ force: true });
-  await page.waitForTimeout(200);
+  // Wait for answers to appear in the DOM
+  await page.waitForFunction(
+    (selector) => {
+      const items = document.querySelectorAll(selector);
+      return (
+        items.length > 0 &&
+        [...items].some((el) => /answer|Answer|\d/.test(el.textContent ?? ''))
+      );
+    },
+    PROBLEM_SELECTOR,
+    { timeout: 5000 }
+  );
   const renderedOn = (await problemLocator.allInnerTexts()).map(normalizeText);
 
   // Validate multi-step answers when answers are visible

--- a/src/lib/generators/assertions.test.ts
+++ b/src/lib/generators/assertions.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertNoDuplicateNames,
+  assertNonEmptyText,
+  assertValidAnswer,
+  assertValidProblem,
+} from './assertions';
+
+describe('assertValidAnswer', () => {
+  it('accepts positive finite numbers', () => {
+    expect(() => assertValidAnswer(42, 'test')).not.toThrow();
+    expect(() => assertValidAnswer(0.5, 'test')).not.toThrow();
+  });
+
+  it('rejects NaN', () => {
+    expect(() => assertValidAnswer(NaN, 'test')).toThrow('not a finite number');
+  });
+
+  it('rejects Infinity', () => {
+    expect(() => assertValidAnswer(Infinity, 'test')).toThrow(
+      'not a finite number'
+    );
+  });
+
+  it('rejects zero', () => {
+    expect(() => assertValidAnswer(0, 'test')).toThrow('must be positive');
+  });
+
+  it('rejects negative numbers', () => {
+    expect(() => assertValidAnswer(-5, 'test')).toThrow('must be positive');
+  });
+
+  it('accepts string answers without validation', () => {
+    expect(() => assertValidAnswer('3/4', 'test')).not.toThrow();
+  });
+});
+
+describe('assertNoDuplicateNames', () => {
+  it('accepts problems with different names', () => {
+    expect(() =>
+      assertNoDuplicateNames(
+        'Maya has 10 stickers. Noah has 5 more than Maya.',
+        'test'
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects self-referential names', () => {
+    expect(() =>
+      assertNoDuplicateNames(
+        'Noah has 10 stickers. Noah has 5 more than Noah.',
+        'test'
+      )
+    ).toThrow('Self-referential name');
+  });
+
+  it('accepts problems without comparison phrases', () => {
+    expect(() =>
+      assertNoDuplicateNames('How many stickers are there in all?', 'test')
+    ).not.toThrow();
+  });
+});
+
+describe('assertNonEmptyText', () => {
+  it('accepts non-empty text', () => {
+    expect(() => assertNonEmptyText('How many?', 'test')).not.toThrow();
+  });
+
+  it('rejects empty string', () => {
+    expect(() => assertNonEmptyText('', 'test')).toThrow('Empty problem text');
+  });
+
+  it('rejects whitespace-only string', () => {
+    expect(() => assertNonEmptyText('   ', 'test')).toThrow(
+      'Empty problem text'
+    );
+  });
+});
+
+describe('assertValidProblem', () => {
+  it('validates a well-formed problem', () => {
+    expect(() =>
+      assertValidProblem(
+        {
+          problemText: 'Maya has 10 stickers. How many are red?',
+          answer: 5,
+        },
+        'test'
+      )
+    ).not.toThrow();
+  });
+
+  it('catches invalid answer in combined check', () => {
+    expect(() =>
+      assertValidProblem({ problemText: 'Some question', answer: -1 }, 'test')
+    ).toThrow('must be positive');
+  });
+});

--- a/src/lib/generators/assertions.ts
+++ b/src/lib/generators/assertions.ts
@@ -1,0 +1,69 @@
+/**
+ * Runtime assertions for problem generators.
+ * These catch bugs (duplicate names, invalid answers, empty text) at generation time
+ * rather than waiting for visual review.
+ */
+
+// Matches "{Name} has N more/fewer than {Name}" where the comparison subject = object.
+// Does NOT span sentences — restricts to a single clause with [^.]*
+const SELF_REFERENCE_RE =
+  /\b([A-Z][a-z]+)\b has \d+[^.]*?(?:more than|fewer than|times as many as) \1\b/;
+
+/**
+ * Assert that a problem's answer is a finite, positive number.
+ * Throws if the answer is NaN, Infinity, negative, or zero.
+ */
+export function assertValidAnswer(
+  answer: number | string,
+  context: string
+): void {
+  if (typeof answer === 'string') {
+    return; // String answers (e.g. "3/4") are validated differently
+  }
+  if (!Number.isFinite(answer)) {
+    throw new Error(
+      `Invalid answer: ${answer} is not a finite number (${context})`
+    );
+  }
+  if (answer <= 0) {
+    throw new Error(`Invalid answer: ${answer} must be positive (${context})`);
+  }
+}
+
+/**
+ * Assert that a two-person problem does not use the same name for both people.
+ */
+export function assertNoDuplicateNames(
+  problemText: string,
+  context: string
+): void {
+  if (SELF_REFERENCE_RE.test(problemText)) {
+    throw new Error(
+      `Self-referential name detected in problem text: "${problemText}" (${context})`
+    );
+  }
+}
+
+/**
+ * Assert that problem text is non-empty and contains meaningful content.
+ */
+export function assertNonEmptyText(problemText: string, context: string): void {
+  if (!problemText || problemText.trim().length === 0) {
+    throw new Error(`Empty problem text (${context})`);
+  }
+}
+
+/**
+ * Validate a generated problem with all applicable assertions.
+ */
+export function assertValidProblem(
+  problem: {
+    problemText: string;
+    answer: number | string;
+  },
+  context: string
+): void {
+  assertNonEmptyText(problem.problemText, context);
+  assertValidAnswer(problem.answer, context);
+  assertNoDuplicateNames(problem.problemText, context);
+}

--- a/src/lib/generators/property-tests.test.ts
+++ b/src/lib/generators/property-tests.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from 'vitest';
+import type { Grade } from '../../types';
+import {
+  generateSingaporeBarModel,
+  generateSingaporeComparison,
+  generateSingaporeMultiStep,
+  generateSingaporeNumberBond,
+  calculateSequentialFractionUsage,
+} from './singapore-problems-en';
+import {
+  generateEnMissingNumber,
+  generateEnWordStory,
+} from './word-problem-en';
+import { generateProblems } from './index';
+
+const SAMPLE_SIZE = 200;
+const GRADES: Grade[] = [1, 2, 3, 4, 5, 6];
+
+const SELF_REFERENCE_RE =
+  /\b([A-Z][a-z]+)\b(?:\s+has\s+\d+.*?(?:more\s+than|fewer\s+than|times\s+as\s+many\s+as))\s+\1\b/;
+
+describe('property-based tests: Singapore Bar Model', () => {
+  it.each(GRADES)(
+    'grade %i: generates 200+ valid problems with unique names',
+    (grade) => {
+      const problems = generateSingaporeBarModel(grade, SAMPLE_SIZE);
+      expect(problems.length).toBe(SAMPLE_SIZE);
+
+      for (const p of problems) {
+        expect(p.type).toBe('singapore');
+        expect(p.category).toBe('bar-model');
+        expect(p.problemText.trim().length).toBeGreaterThan(0);
+        expect(typeof p.answer).toBe('number');
+        expect(Number.isFinite(p.answer)).toBe(true);
+        expect(p.answer).toBeGreaterThan(0);
+        expect(SELF_REFERENCE_RE.test(p.problemText)).toBe(false);
+      }
+    }
+  );
+
+  it.each(GRADES)('grade %i: bar model diagram math is consistent', (grade) => {
+    const problems = generateSingaporeBarModel(grade, SAMPLE_SIZE);
+
+    for (const p of problems) {
+      if (!p.diagram || p.diagram.diagramType !== 'bar-model') continue;
+
+      if (p.diagram.variant === 'part-whole') {
+        const segmentSum = p.diagram.segments.reduce(
+          (sum, s) => sum + s.value,
+          0
+        );
+        expect(segmentSum).toBe(p.diagram.totalValue);
+      }
+
+      if (p.diagram.variant === 'comparison') {
+        const bigger = Math.max(...p.diagram.bars.map((b) => b.value));
+        const smaller = Math.min(...p.diagram.bars.map((b) => b.value));
+        expect(bigger - smaller).toBe(p.diagram.differenceValue);
+      }
+    }
+  });
+});
+
+describe('property-based tests: Singapore Number Bond', () => {
+  it.each(GRADES)(
+    'grade %i: generates 200+ valid number bond problems',
+    (grade) => {
+      const problems = generateSingaporeNumberBond(grade, SAMPLE_SIZE);
+      expect(problems.length).toBe(SAMPLE_SIZE);
+
+      for (const p of problems) {
+        expect(p.type).toBe('singapore');
+        expect(p.category).toBe('number-bond');
+        expect(p.problemText.trim().length).toBeGreaterThan(0);
+        expect(typeof p.answer).toBe('number');
+        expect(Number.isFinite(p.answer)).toBe(true);
+        expect(p.answer).toBeGreaterThan(0);
+      }
+    }
+  );
+
+  it.each(GRADES)('grade %i: number bond parts sum to whole', (grade) => {
+    const problems = generateSingaporeNumberBond(grade, SAMPLE_SIZE);
+
+    for (const p of problems) {
+      if (!p.diagram || p.diagram.diagramType !== 'number-bond') continue;
+      const partsSum = p.diagram.parts.reduce((sum, v) => sum + v, 0);
+      expect(partsSum).toBe(p.diagram.whole);
+    }
+  });
+});
+
+describe('property-based tests: Singapore Comparison', () => {
+  it.each(GRADES)(
+    'grade %i: generates 200+ valid comparison problems with unique names',
+    (grade) => {
+      const problems = generateSingaporeComparison(grade, SAMPLE_SIZE);
+      expect(problems.length).toBe(SAMPLE_SIZE);
+
+      for (const p of problems) {
+        expect(p.type).toBe('singapore');
+        expect(p.category).toBe('comparison');
+        expect(p.problemText.trim().length).toBeGreaterThan(0);
+        expect(typeof p.answer).toBe('number');
+        expect(Number.isFinite(p.answer)).toBe(true);
+        expect(p.answer).toBeGreaterThan(0);
+        expect(SELF_REFERENCE_RE.test(p.problemText)).toBe(false);
+      }
+    }
+  );
+
+  it('grade 2: uses only additive comparison (no multiplication)', () => {
+    const problems = generateSingaporeComparison(2, SAMPLE_SIZE);
+
+    for (const p of problems) {
+      expect(p.operation === 'addition' || p.operation === 'subtraction').toBe(
+        true
+      );
+      expect(p.problemText).not.toContain('times as many');
+      expect(
+        p.problemText.includes('more') || p.problemText.includes('fewer')
+      ).toBe(true);
+    }
+  });
+
+  it.each([3, 4, 5, 6] as Grade[])(
+    'grade %i: uses multiplicative comparison',
+    (grade) => {
+      const problems = generateSingaporeComparison(grade, SAMPLE_SIZE);
+
+      for (const p of problems) {
+        expect(p.operation).toBe('multiplication');
+        expect(p.problemText).toContain('times as many');
+      }
+    }
+  );
+
+  it.each(GRADES)(
+    'grade %i: comparison diagram math is consistent',
+    (grade) => {
+      const problems = generateSingaporeComparison(grade, SAMPLE_SIZE);
+
+      for (const p of problems) {
+        if (!p.diagram || p.diagram.diagramType !== 'comparison') continue;
+        const bigger = Math.max(...p.diagram.bars.map((b) => b.value));
+        const smaller = Math.min(...p.diagram.bars.map((b) => b.value));
+        expect(bigger - smaller).toBe(p.diagram.differenceValue);
+      }
+    }
+  );
+});
+
+describe('property-based tests: Singapore Multi-Step', () => {
+  it.each([3, 4, 5, 6] as Grade[])(
+    'grade %i: generates 200+ valid multi-step problems',
+    (grade) => {
+      const problems = generateSingaporeMultiStep(grade, SAMPLE_SIZE);
+      expect(problems.length).toBe(SAMPLE_SIZE);
+
+      for (const p of problems) {
+        expect(p.type).toBe('singapore');
+        expect(p.category).toBe('multi-step');
+        expect(p.problemText.trim().length).toBeGreaterThan(0);
+        expect(typeof p.answer).toBe('number');
+        expect(Number.isFinite(p.answer)).toBe(true);
+        expect(Number.isInteger(p.answer)).toBe(true);
+        expect(p.answer).toBeGreaterThan(0);
+        expect(p.problemText).toContain('/');
+      }
+    }
+  );
+
+  it.each([3, 4, 5, 6] as Grade[])(
+    'grade %i: multi-step answers match reverse-calculated values',
+    (grade) => {
+      const problems = generateSingaporeMultiStep(grade, SAMPLE_SIZE);
+
+      for (const p of problems) {
+        const fractions = [...p.problemText.matchAll(/(\d+)\/(\d+)/g)];
+        const totalMatch = p.problemText.match(/(?:has|are) (\d+) /);
+        expect(fractions.length).toBeGreaterThanOrEqual(2);
+        expect(totalMatch).toBeDefined();
+
+        const total = Number(totalMatch![1]);
+        const usage = calculateSequentialFractionUsage(total, {
+          fraction1Numerator: Number(fractions[0][1]),
+          fraction1Denominator: Number(fractions[0][2]),
+          fraction2Numerator: Number(fractions[1][1]),
+          fraction2Denominator: Number(fractions[1][2]),
+          lcm: 1,
+        });
+        expect(usage).not.toBeNull();
+
+        if (p.operation === 'subtraction') {
+          expect(p.answer).toBe(usage!.remainingAfterSecond);
+        } else {
+          const groupsMatch = p.problemText.match(/among (\d+) students/);
+          expect(groupsMatch).toBeDefined();
+          const groups = Number(groupsMatch![1]);
+          expect(p.answer).toBe(usage!.remainingAfterSecond / groups);
+        }
+      }
+    }
+  );
+});
+
+describe('property-based tests: English Word Problems', () => {
+  it.each(GRADES)('grade %i: missing number problems are valid', (grade) => {
+    const problems = generateEnMissingNumber(grade, SAMPLE_SIZE);
+    // May generate fewer than SAMPLE_SIZE due to deduplication
+    expect(problems.length).toBeGreaterThan(0);
+
+    for (const p of problems) {
+      expect(p.type).toBe('word-en');
+      expect(p.problemText.trim().length).toBeGreaterThan(0);
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isFinite(p.answer as number)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(GRADES)('grade %i: word story problems are valid', (grade) => {
+    const problems = generateEnWordStory(grade, SAMPLE_SIZE);
+    expect(problems.length).toBe(SAMPLE_SIZE);
+
+    for (const p of problems) {
+      expect(p.type).toBe('word-en');
+      expect(p.problemText.trim().length).toBeGreaterThan(0);
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isFinite(p.answer as number)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('property-based tests: pattern router integration', () => {
+  const englishPatterns = [
+    'word-en',
+    'singapore-bar-model',
+    'singapore-number-bond',
+    'singapore-comparison',
+    'singapore-multi-step',
+    'money-change-en',
+    'money-total-en',
+    'money-payment-en',
+    'time-reading-en',
+    'time-elapsed-en',
+    'time-calc-en',
+    'unit-length-en',
+    'unit-weight-en',
+    'unit-capacity-en',
+    'shopping-discount-en',
+    'shopping-budget-en',
+    'shopping-comparison-en',
+    'temperature-diff-en',
+    'temperature-conversion-en',
+    'distance-walk-en',
+    'distance-map-scale-en',
+    'distance-comparison-en',
+    'cooking-ingredients-en',
+    'cooking-time-en',
+    'cooking-serving-en',
+    'calendar-days-en',
+    'calendar-week-en',
+    'calendar-age-en',
+    'energy-usage-en',
+    'energy-saving-en',
+    'transport-fare-en',
+    'transport-change-en',
+    'transport-discount-en',
+    'allowance-saving-en',
+    'allowance-goal-en',
+  ] as const;
+
+  // Test each English pattern at grade 3 (most patterns available)
+  it.each(englishPatterns)('pattern %s generates valid problems', (pattern) => {
+    // Skip patterns not available at grade 3
+    const grade = pattern.includes('singapore-multi-step') ? 3 : 3;
+    const count = 20;
+
+    const problems = generateProblems({
+      grade: grade as Grade,
+      problemType: 'basic',
+      operation: 'addition',
+      problemCount: count,
+      layoutColumns: 1,
+      calculationPattern: pattern,
+    });
+
+    expect(problems.length).toBe(count);
+
+    for (const p of problems) {
+      if ('problemText' in p) {
+        expect((p.problemText as string).trim().length).toBeGreaterThan(0);
+      }
+      if ('answer' in p && typeof p.answer === 'number') {
+        expect(Number.isFinite(p.answer)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/lib/generators/property-tests.test.ts
+++ b/src/lib/generators/property-tests.test.ts
@@ -12,12 +12,10 @@ import {
   generateEnWordStory,
 } from './word-problem-en';
 import { generateProblems } from './index';
+import { assertNoDuplicateNames } from './assertions';
 
 const SAMPLE_SIZE = 200;
 const GRADES: Grade[] = [1, 2, 3, 4, 5, 6];
-
-const SELF_REFERENCE_RE =
-  /\b([A-Z][a-z]+)\b(?:\s+has\s+\d+.*?(?:more\s+than|fewer\s+than|times\s+as\s+many\s+as))\s+\1\b/;
 
 describe('property-based tests: Singapore Bar Model', () => {
   it.each(GRADES)(
@@ -33,7 +31,9 @@ describe('property-based tests: Singapore Bar Model', () => {
         expect(typeof p.answer).toBe('number');
         expect(Number.isFinite(p.answer)).toBe(true);
         expect(p.answer).toBeGreaterThan(0);
-        expect(SELF_REFERENCE_RE.test(p.problemText)).toBe(false);
+        expect(() =>
+          assertNoDuplicateNames(p.problemText, 'test')
+        ).not.toThrow();
       }
     }
   );
@@ -104,7 +104,9 @@ describe('property-based tests: Singapore Comparison', () => {
         expect(typeof p.answer).toBe('number');
         expect(Number.isFinite(p.answer)).toBe(true);
         expect(p.answer).toBeGreaterThan(0);
-        expect(SELF_REFERENCE_RE.test(p.problemText)).toBe(false);
+        expect(() =>
+          assertNoDuplicateNames(p.problemText, 'test')
+        ).not.toThrow();
       }
     }
   );
@@ -274,8 +276,7 @@ describe('property-based tests: pattern router integration', () => {
 
   // Test each English pattern at grade 3 (most patterns available)
   it.each(englishPatterns)('pattern %s generates valid problems', (pattern) => {
-    // Skip patterns not available at grade 3
-    const grade = pattern.includes('singapore-multi-step') ? 3 : 3;
+    const grade = 3;
     const count = 20;
 
     const problems = generateProblems({

--- a/src/lib/generators/singapore-problems-en.ts
+++ b/src/lib/generators/singapore-problems-en.ts
@@ -8,6 +8,7 @@ import type {
   ComparisonDiagram,
 } from '../../types';
 import { generateId, randomInt } from '../utils/math';
+import { assertValidProblem } from './assertions';
 
 type FractionScenario = {
   fraction1Numerator: number;
@@ -250,6 +251,7 @@ export function generateSingaporeBarModel(
     }
   }
 
+  problems.forEach((p) => assertValidProblem(p, 'singapore-bar-model'));
   return problems;
 }
 
@@ -307,7 +309,11 @@ export function generateSingaporeNumberBond(
         { min: 100, max: 900 },
         { min: 1000, max: 9000 }
       );
-      const value = randomInt(base.min, base.max);
+      // Ensure the hidden part (ones digit) is non-zero
+      let value = randomInt(base.min, base.max);
+      while (value % 10 === 0) {
+        value = randomInt(base.min, base.max);
+      }
 
       if (grade <= 2) {
         const tens = Math.floor(value / 10) * 10;
@@ -390,6 +396,7 @@ export function generateSingaporeNumberBond(
     });
   }
 
+  problems.forEach((p) => assertValidProblem(p, 'singapore-number-bond'));
   return problems;
 }
 
@@ -529,6 +536,7 @@ export function generateSingaporeComparison(
     });
   }
 
+  problems.forEach((p) => assertValidProblem(p, 'singapore-comparison'));
   return problems;
 }
 
@@ -682,5 +690,6 @@ export function generateSingaporeMultiStep(
     });
   }
 
+  problems.forEach((p) => assertValidProblem(p, 'singapore-multi-step'));
   return problems;
 }

--- a/src/lib/generators/word-problem-en.ts
+++ b/src/lib/generators/word-problem-en.ts
@@ -1,5 +1,6 @@
 import type { Grade, WordProblemEn } from '../../types';
 import { generateId, randomInt } from '../utils/math';
+import { assertValidProblem } from './assertions';
 import {
   getTemplatesForGrade,
   type MissingNumberTemplate,
@@ -25,8 +26,7 @@ export function generateEnMissingNumber(
 
     while (!problem && attempts < maxAttempts) {
       // Select random template
-      const template =
-        templates[randomInt(0, templates.length - 1)];
+      const template = templates[randomInt(0, templates.length - 1)];
 
       // Generate numbers based on operation
       const { problemText, answer, key } = generateProblemFromTemplate(
@@ -57,6 +57,7 @@ export function generateEnMissingNumber(
     }
   }
 
+  problems.forEach((p) => assertValidProblem(p, 'word-en-missing-number'));
   return problems;
 }
 
@@ -93,6 +94,7 @@ export function generateEnWordStory(
     });
   }
 
+  problems.forEach((p) => assertValidProblem(p, 'word-en-story'));
   return problems;
 }
 
@@ -166,4 +168,3 @@ function generateProblemFromTemplate(
 
   return { problemText, answer, key };
 }
-


### PR DESCRIPTION
## Summary
- Add runtime assertions (`assertValidAnswer`, `assertNoDuplicateNames`, `assertNonEmptyText`) that catch bugs at generation time
- Add 110 property-based tests generating 200+ samples per generator/grade — verifying name uniqueness, mathematical correctness, grade constraints, and diagram consistency
- Extend Playwright verification script from 9 Singapore combos to 54 combos covering all problem types
- Fix number bond generator producing zero answers for round numbers (e.g., 30 → ones = 0)
- Add Playwright MCP integration documentation for AI-assisted verification workflow

Closes #50

## Changes
| File | Purpose |
|------|---------|
| `src/lib/generators/assertions.ts` | Runtime assertion functions |
| `src/lib/generators/assertions.test.ts` | Unit tests for assertions (14 tests) |
| `src/lib/generators/property-tests.test.ts` | Property-based tests (96 tests) |
| `src/lib/generators/singapore-problems-en.ts` | Integrate assertions + fix zero-answer bug |
| `src/lib/generators/word-problem-en.ts` | Integrate assertions |
| `scripts/verify-playwright.mjs` | Extended Playwright verification (all patterns) |
| `docs/testing/playwright-mcp-verification.md` | Playwright MCP integration docs |
| `package.json` | npm scripts: `verify:playwright`, `verify:singapore` |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test -- --run` passes (596 tests, up from 459)
- [x] `npm run build` succeeds
- [ ] Run `npm run verify:playwright` locally with dev server to verify Playwright screenshots
- [ ] Verify no new CI jobs added — Playwright checks remain local only

🤖 Generated with [Claude Code](https://claude.com/claude-code)