### PR TITLE
feat: Add Singapore Math problems for Grade 4-6 (Primary 4-6)

### DIFF
--- a/scripts/verify-singapore-playwright.mjs
+++ b/scripts/verify-singapore-playwright.mjs
@@ -17,6 +17,37 @@ const COMBOS = [
   { grade: 3, pattern: 'singapore-number-bond', slug: 'grade3-number-bond' },
   { grade: 3, pattern: 'singapore-comparison', slug: 'grade3-comparison' },
   { grade: 3, pattern: 'singapore-multi-step', slug: 'grade3-multi-step' },
+  // Grade 4
+  { grade: 4, pattern: 'singapore-bar-model', slug: 'grade4-bar-model' },
+  { grade: 4, pattern: 'singapore-number-bond', slug: 'grade4-number-bond' },
+  { grade: 4, pattern: 'singapore-comparison', slug: 'grade4-comparison' },
+  { grade: 4, pattern: 'singapore-multi-step', slug: 'grade4-multi-step' },
+  { grade: 4, pattern: 'singapore-fraction-set', slug: 'grade4-fraction-set' },
+  { grade: 4, pattern: 'singapore-decimal', slug: 'grade4-decimal' },
+  // Grade 5
+  { grade: 5, pattern: 'singapore-fraction-set', slug: 'grade5-fraction-set' },
+  { grade: 5, pattern: 'singapore-decimal', slug: 'grade5-decimal' },
+  { grade: 5, pattern: 'singapore-ratio', slug: 'grade5-ratio' },
+  { grade: 5, pattern: 'singapore-percentage', slug: 'grade5-percentage' },
+  { grade: 5, pattern: 'singapore-rate', slug: 'grade5-rate' },
+  { grade: 5, pattern: 'singapore-volume', slug: 'grade5-volume' },
+  // Grade 6
+  { grade: 6, pattern: 'singapore-ratio', slug: 'grade6-ratio' },
+  { grade: 6, pattern: 'singapore-percentage', slug: 'grade6-percentage' },
+  { grade: 6, pattern: 'singapore-rate', slug: 'grade6-rate' },
+  { grade: 6, pattern: 'singapore-volume', slug: 'grade6-volume' },
+  { grade: 6, pattern: 'singapore-algebra', slug: 'grade6-algebra' },
+  {
+    grade: 6,
+    pattern: 'singapore-ratio-advanced',
+    slug: 'grade6-ratio-advanced',
+  },
+  { grade: 6, pattern: 'singapore-circle', slug: 'grade6-circle' },
+  {
+    grade: 6,
+    pattern: 'singapore-data-analysis',
+    slug: 'grade6-data-analysis',
+  },
 ];
 
 const SELF_REFERENCE_RE =
@@ -95,7 +126,10 @@ function validateMultiStepAnswer(renderedProblem, combo) {
     expectedAnswer = remainingAfterSecond / groups;
   }
 
-  if (!Number.isFinite(expectedAnswer) || Math.abs(answer - expectedAnswer) > 1e-9) {
+  if (
+    !Number.isFinite(expectedAnswer) ||
+    Math.abs(answer - expectedAnswer) > 1e-9
+  ) {
     throw new Error(
       `Multi-step answer mismatch in ${combo.slug}: expected ${expectedAnswer}, got ${answer}, text="${renderedProblem}"`
     );
@@ -116,7 +150,9 @@ async function captureCombo(page, combo) {
     input.click();
   }, combo.pattern);
 
-  await page.locator('[data-a4-sheet]').waitFor({ state: 'visible', timeout: 10000 });
+  await page
+    .locator('[data-a4-sheet]')
+    .waitFor({ state: 'visible', timeout: 10000 });
   await page.waitForFunction(
     ({ pattern }) => {
       const patternInput = document.querySelector(
@@ -154,7 +190,9 @@ async function captureCombo(page, combo) {
   await answerToggle.check({ force: true });
   await page.waitForTimeout(200);
   const renderedOn = (await problemLocator.allInnerTexts()).map(normalizeText);
-  renderedOn.forEach((renderedProblem) => validateMultiStepAnswer(renderedProblem, combo));
+  renderedOn.forEach((renderedProblem) =>
+    validateMultiStepAnswer(renderedProblem, combo)
+  );
   await page.screenshot({
     path: join(OUTPUT_DIR, `${combo.slug}-answers-on.png`),
     fullPage: true,

--- a/src/config/pattern-categories.ts
+++ b/src/config/pattern-categories.ts
@@ -295,6 +295,16 @@ const BASE_DIFFICULTY: Partial<Record<CalculationPattern, DifficultyLevel>> = {
   'singapore-number-bond': 1,
   'singapore-comparison': 2,
   'singapore-multi-step': 3,
+  'singapore-fraction-set': 2,
+  'singapore-decimal': 2,
+  'singapore-ratio': 3,
+  'singapore-percentage': 3,
+  'singapore-rate': 3,
+  'singapore-volume': 3,
+  'singapore-algebra': 3,
+  'singapore-ratio-advanced': 3,
+  'singapore-circle': 3,
+  'singapore-data-analysis': 3,
 
   // === 暗算のコツ (anzan) ===
   'anzan-complement-10': 1,

--- a/src/config/print-templates.ts
+++ b/src/config/print-templates.ts
@@ -449,62 +449,32 @@ export const PATTERN_COUNT_OVERRIDES: Partial<
     recommendedCounts: { 1: 5, 2: 10, 3: 15 },
     maxCounts: { 1: 6, 2: 12, 3: 15 },
   },
-  'singapore-bar-model': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-number-bond': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-comparison': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-multi-step': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-fraction-set': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-decimal': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-ratio': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-percentage': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-rate': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-volume': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-algebra': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-ratio-advanced': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-circle': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
-  'singapore-data-analysis': {
-    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
-    maxCounts: { 1: 6, 2: 10, 3: 12 },
-  },
+  ...Object.fromEntries(
+    (
+      [
+        'singapore-bar-model',
+        'singapore-number-bond',
+        'singapore-comparison',
+        'singapore-multi-step',
+        'singapore-fraction-set',
+        'singapore-decimal',
+        'singapore-ratio',
+        'singapore-percentage',
+        'singapore-rate',
+        'singapore-volume',
+        'singapore-algebra',
+        'singapore-ratio-advanced',
+        'singapore-circle',
+        'singapore-data-analysis',
+      ] as const
+    ).map((pattern) => [
+      pattern,
+      {
+        recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+        maxCounts: { 1: 6, 2: 10, 3: 12 },
+      },
+    ])
+  ),
 };
 
 /**

--- a/src/config/print-templates.ts
+++ b/src/config/print-templates.ts
@@ -465,6 +465,46 @@ export const PATTERN_COUNT_OVERRIDES: Partial<
     recommendedCounts: { 1: 5, 2: 8, 3: 12 },
     maxCounts: { 1: 6, 2: 10, 3: 12 },
   },
+  'singapore-fraction-set': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-decimal': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-ratio': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-percentage': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-rate': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-volume': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-algebra': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-ratio-advanced': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-circle': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
+  'singapore-data-analysis': {
+    recommendedCounts: { 1: 5, 2: 8, 3: 12 },
+    maxCounts: { 1: 6, 2: 10, 3: 12 },
+  },
 };
 
 /**

--- a/src/config/problem-patterns.ts
+++ b/src/config/problem-patterns.ts
@@ -13,6 +13,16 @@ export const SINGAPORE_MATH_PATTERNS: readonly CalculationPattern[] = [
   'singapore-number-bond',
   'singapore-comparison',
   'singapore-multi-step',
+  'singapore-fraction-set',
+  'singapore-decimal',
+  'singapore-ratio',
+  'singapore-percentage',
+  'singapore-rate',
+  'singapore-volume',
+  'singapore-algebra',
+  'singapore-ratio-advanced',
+  'singapore-circle',
+  'singapore-data-analysis',
 ] as const;
 
 export const WORD_PROBLEM_PATTERNS: readonly CalculationPattern[] = [

--- a/src/lib/generators/patterns/index.ts
+++ b/src/lib/generators/patterns/index.ts
@@ -27,6 +27,16 @@ import {
   generateSingaporeComparison,
   generateSingaporeMultiStep,
   generateSingaporeNumberBond,
+  generateSingaporeFractionSet,
+  generateSingaporeDecimal,
+  generateSingaporeRatio,
+  generateSingaporePercentage,
+  generateSingaporeRate,
+  generateSingaporeVolume,
+  generateSingaporeAlgebra,
+  generateSingaporeRatioAdvanced,
+  generateSingaporeCircle,
+  generateSingaporeDataAnalysis,
 } from '../singapore-problems-en';
 import {
   generateComplement10,
@@ -278,6 +288,26 @@ export function generatePatternProblems(
       return generateSingaporeComparison(settings.grade, count);
     case 'singapore-multi-step':
       return generateSingaporeMultiStep(settings.grade, count);
+    case 'singapore-fraction-set':
+      return generateSingaporeFractionSet(settings.grade, count);
+    case 'singapore-decimal':
+      return generateSingaporeDecimal(settings.grade, count);
+    case 'singapore-ratio':
+      return generateSingaporeRatio(settings.grade, count);
+    case 'singapore-percentage':
+      return generateSingaporePercentage(settings.grade, count);
+    case 'singapore-rate':
+      return generateSingaporeRate(settings.grade, count);
+    case 'singapore-volume':
+      return generateSingaporeVolume(settings.grade, count);
+    case 'singapore-algebra':
+      return generateSingaporeAlgebra(settings.grade, count);
+    case 'singapore-ratio-advanced':
+      return generateSingaporeRatioAdvanced(settings.grade, count);
+    case 'singapore-circle':
+      return generateSingaporeCircle(settings.grade, count);
+    case 'singapore-data-analysis':
+      return generateSingaporeDataAnalysis(settings.grade, count);
 
     // お金の計算（日本円）
     case 'money-change-jap':

--- a/src/lib/generators/singapore-problems-en.test.ts
+++ b/src/lib/generators/singapore-problems-en.test.ts
@@ -7,6 +7,16 @@ import {
   generateSingaporeComparison,
   generateSingaporeMultiStep,
   generateSingaporeNumberBond,
+  generateSingaporeFractionSet,
+  generateSingaporeDecimal,
+  generateSingaporeRatio,
+  generateSingaporePercentage,
+  generateSingaporeRate,
+  generateSingaporeVolume,
+  generateSingaporeAlgebra,
+  generateSingaporeRatioAdvanced,
+  generateSingaporeCircle,
+  generateSingaporeDataAnalysis,
 } from './singapore-problems-en';
 
 describe('singapore-problems-en generators', () => {
@@ -168,6 +178,283 @@ describe('singapore-problems-en generators', () => {
   });
 });
 
+// ── Grade 4-6 generator tests ────────────────────────────────────────
+
+describe('singapore-fraction-set generator', () => {
+  it('generates fraction-set problems for grade 4', () => {
+    const problems = generateSingaporeFractionSet(4, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.language).toBe('en');
+      expect(p.category).toBe('fraction-set');
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isInteger(p.answer)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('produces valid problems across 200 samples', () => {
+    const problems = generateSingaporeFractionSet(5, 200);
+    expect(problems).toHaveLength(200);
+    problems.forEach((p) => {
+      expect(typeof p.answer).toBe('number');
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('singapore-decimal generator', () => {
+  it('generates decimal word problems for grade 4', () => {
+    const problems = generateSingaporeDecimal(4, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.language).toBe('en');
+      expect(p.category).toBe('decimal');
+      expect(typeof p.answer).toBe('number');
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('never reuses the same name in two-person prompts across 200 samples', () => {
+    const problems = generateSingaporeDecimal(5, 200);
+    const selfRef =
+      /\b([A-Z][a-z]+)\b has \d+[^.]*?(?:more than|fewer than|times as many as) \1\b/;
+    problems.forEach((p) => {
+      expect(selfRef.test(p.problemText)).toBe(false);
+    });
+  });
+});
+
+describe('singapore-ratio generator', () => {
+  it('generates ratio problems for grade 5', () => {
+    const problems = generateSingaporeRatio(5, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.category).toBe('ratio');
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isInteger(p.answer)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('produces valid problems across 200 samples', () => {
+    const problems = generateSingaporeRatio(6, 200);
+    expect(problems).toHaveLength(200);
+    problems.forEach((p) => {
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('never reuses the same name in two-person prompts', () => {
+    const problems = generateSingaporeRatio(5, 200);
+    const selfRef =
+      /\b([A-Z][a-z]+)\b has \d+[^.]*?(?:more than|fewer than|times as many as) \1\b/;
+    problems.forEach((p) => {
+      expect(selfRef.test(p.problemText)).toBe(false);
+    });
+  });
+});
+
+describe('singapore-percentage generator', () => {
+  it('generates percentage problems for grade 5', () => {
+    const problems = generateSingaporePercentage(5, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.category).toBe('percentage');
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isInteger(p.answer)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('produces valid problems across 200 samples', () => {
+    const problems = generateSingaporePercentage(6, 200);
+    expect(problems).toHaveLength(200);
+    problems.forEach((p) => {
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('singapore-rate generator', () => {
+  it('generates speed/distance/time problems for grade 5', () => {
+    const problems = generateSingaporeRate(5, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.category).toBe('rate');
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isInteger(p.answer)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('verifies distance = speed × time across 200 samples', () => {
+    const problems = generateSingaporeRate(6, 200);
+    expect(problems).toHaveLength(200);
+    problems.forEach((p) => {
+      expect(p.answer).toBeGreaterThan(0);
+      // All rate answers should be whole numbers
+      expect(Number.isInteger(p.answer)).toBe(true);
+    });
+  });
+});
+
+describe('singapore-volume generator', () => {
+  it('generates volume problems for grade 5', () => {
+    const problems = generateSingaporeVolume(5, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.category).toBe('volume');
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isInteger(p.answer)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('produces valid problems across 200 samples', () => {
+    const problems = generateSingaporeVolume(6, 200);
+    expect(problems).toHaveLength(200);
+    problems.forEach((p) => {
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('singapore-algebra generator', () => {
+  it('generates algebra problems for grade 6', () => {
+    const problems = generateSingaporeAlgebra(6, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.category).toBe('algebra');
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isInteger(p.answer)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('produces valid problems across 200 samples', () => {
+    const problems = generateSingaporeAlgebra(6, 200);
+    expect(problems).toHaveLength(200);
+    problems.forEach((p) => {
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('verifies ax + b = c equation answers', () => {
+    const problems = generateSingaporeAlgebra(6, 200);
+    problems.forEach((p) => {
+      const addMatch = p.problemText.match(/(\d+)x \+ (\d+) = (\d+)/);
+      if (addMatch) {
+        const a = Number(addMatch[1]);
+        const b = Number(addMatch[2]);
+        const c = Number(addMatch[3]);
+        expect(p.answer).toBe((c - b) / a);
+      }
+      const subMatch = p.problemText.match(/(\d+)x − (\d+) = (\d+)/);
+      if (subMatch) {
+        const a = Number(subMatch[1]);
+        const b = Number(subMatch[2]);
+        const c = Number(subMatch[3]);
+        expect(p.answer).toBe((c + b) / a);
+      }
+    });
+  });
+});
+
+describe('singapore-ratio-advanced generator', () => {
+  it('generates advanced ratio problems for grade 6', () => {
+    const problems = generateSingaporeRatioAdvanced(6, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.category).toBe('ratio-advanced');
+      expect(typeof p.answer).toBe('number');
+      expect(Number.isInteger(p.answer)).toBe(true);
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('never reuses names and produces 200 valid samples', () => {
+    const problems = generateSingaporeRatioAdvanced(6, 200);
+    const selfRef =
+      /\b([A-Z][a-z]+)\b has \d+[^.]*?(?:more than|fewer than|times as many as) \1\b/;
+    problems.forEach((p) => {
+      expect(selfRef.test(p.problemText)).toBe(false);
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('singapore-circle generator', () => {
+  it('generates circle problems for grade 6', () => {
+    const problems = generateSingaporeCircle(6, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.category).toBe('circle');
+      expect(typeof p.answer).toBe('number');
+      expect(p.answer).toBeGreaterThan(0);
+      expect(p.problemText).toContain('π = 3.14');
+    });
+  });
+
+  it('verifies circumference and area calculations across 200 samples', () => {
+    const PI = 3.14;
+    const problems = generateSingaporeCircle(6, 200);
+    expect(problems).toHaveLength(200);
+    problems.forEach((p) => {
+      const radiusMatch = p.problemText.match(/radius of (\d+) cm/);
+      const diameterMatch = p.problemText.match(/diameter of (\d+) cm/);
+      if (p.problemText.includes('area') && radiusMatch) {
+        const r = Number(radiusMatch[1]);
+        expect(p.answer).toBe(Math.round(PI * r * r * 100) / 100);
+      } else if (p.problemText.includes('circumference') && radiusMatch) {
+        const r = Number(radiusMatch[1]);
+        expect(p.answer).toBe(Math.round(2 * PI * r * 100) / 100);
+      } else if (p.problemText.includes('circumference') && diameterMatch) {
+        const d = Number(diameterMatch[1]);
+        expect(p.answer).toBe(Math.round(PI * d * 100) / 100);
+      }
+    });
+  });
+});
+
+describe('singapore-data-analysis generator', () => {
+  it('generates data analysis problems for grade 6', () => {
+    const problems = generateSingaporeDataAnalysis(6, 10);
+    expect(problems).toHaveLength(10);
+    problems.forEach((p) => {
+      expect(p.type).toBe('singapore');
+      expect(p.category).toBe('data-analysis');
+      expect(typeof p.answer).toBe('number');
+      expect(p.answer).toBeGreaterThan(0);
+    });
+  });
+
+  it('verifies mean calculations across 200 samples', () => {
+    const problems = generateSingaporeDataAnalysis(6, 200);
+    expect(problems).toHaveLength(200);
+    problems.forEach((p) => {
+      if (p.problemText.includes('mean')) {
+        // Extract numbers from the problem text
+        const dataMatch = p.problemText.match(/: (.+)\.$/);
+        if (dataMatch) {
+          const numbers = dataMatch[1].split(', ').map(Number);
+          const sum = numbers.reduce((a, b) => a + b, 0);
+          expect(p.answer).toBe(sum / numbers.length);
+        }
+      }
+    });
+  });
+});
+
 describe('singapore pattern router integration', () => {
   const baseSettings: Omit<WorksheetSettings, 'calculationPattern'> = {
     grade: 5,
@@ -182,6 +469,16 @@ describe('singapore pattern router integration', () => {
     'singapore-number-bond',
     'singapore-comparison',
     'singapore-multi-step',
+    'singapore-fraction-set',
+    'singapore-decimal',
+    'singapore-ratio',
+    'singapore-percentage',
+    'singapore-rate',
+    'singapore-volume',
+    'singapore-algebra',
+    'singapore-ratio-advanced',
+    'singapore-circle',
+    'singapore-data-analysis',
   ] as const)('routes %s through generateProblems', (calculationPattern) => {
     const problems = generateProblems({
       ...baseSettings,

--- a/src/lib/generators/singapore-problems-en.test.ts
+++ b/src/lib/generators/singapore-problems-en.test.ts
@@ -421,6 +421,8 @@ describe('singapore-circle generator', () => {
       } else if (p.problemText.includes('circumference') && diameterMatch) {
         const d = Number(diameterMatch[1]);
         expect(p.answer).toBe(Math.round(PI * d * 100) / 100);
+      } else {
+        throw new Error(`Unhandled circle problem variant: "${p.problemText}"`);
       }
     });
   });
@@ -438,18 +440,35 @@ describe('singapore-data-analysis generator', () => {
     });
   });
 
-  it('verifies mean calculations across 200 samples', () => {
+  it('verifies mean, median, and mode calculations across 200 samples', () => {
     const problems = generateSingaporeDataAnalysis(6, 200);
     expect(problems).toHaveLength(200);
     problems.forEach((p) => {
+      const dataMatch = p.problemText.match(/: (.+)\.$/);
+      expect(dataMatch).not.toBeNull();
+      const numbers = dataMatch![1].split(', ').map(Number);
+
       if (p.problemText.includes('mean')) {
-        // Extract numbers from the problem text
-        const dataMatch = p.problemText.match(/: (.+)\.$/);
-        if (dataMatch) {
-          const numbers = dataMatch[1].split(', ').map(Number);
-          const sum = numbers.reduce((a, b) => a + b, 0);
-          expect(p.answer).toBe(sum / numbers.length);
-        }
+        const sum = numbers.reduce((a, b) => a + b, 0);
+        expect(p.answer).toBe(sum / numbers.length);
+      } else if (p.problemText.includes('median')) {
+        const sorted = [...numbers].sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        expect(p.answer).toBe(sorted[mid]);
+      } else if (p.problemText.includes('mode')) {
+        const freq = new Map<number, number>();
+        numbers.forEach((n) => freq.set(n, (freq.get(n) ?? 0) + 1));
+        let maxFreq = 0;
+        let mode = 0;
+        freq.forEach((count, val) => {
+          if (count > maxFreq) {
+            maxFreq = count;
+            mode = val;
+          }
+        });
+        expect(p.answer).toBe(mode);
+      } else {
+        throw new Error(`Unhandled data analysis type: "${p.problemText}"`);
       }
     });
   });

--- a/src/lib/generators/singapore-problems-en.ts
+++ b/src/lib/generators/singapore-problems-en.ts
@@ -693,3 +693,776 @@ export function generateSingaporeMultiStep(
   problems.forEach((p) => assertValidProblem(p, 'singapore-multi-step'));
   return problems;
 }
+
+// ── Grade 4+ generators ──────────────────────────────────────────────
+
+/**
+ * Fraction of a set and equivalent fractions (Primary 4+).
+ */
+export function generateSingaporeFractionSet(
+  grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const items = ['marbles', 'stickers', 'pencils', 'books', 'cookies'];
+  const names = ['Aiden', 'Maya', 'Noah', 'Emma', 'Liam', 'Zoe'];
+
+  const denominators =
+    grade <= 4 ? [2, 3, 4, 5, 6] : [2, 3, 4, 5, 6, 8, 10, 12];
+
+  for (let i = 0; i < count; i++) {
+    const item = items[randomInt(0, items.length - 1)];
+    const name = names[randomInt(0, names.length - 1)];
+    const problemType = randomInt(0, 1);
+
+    if (problemType === 0) {
+      // Fraction of a set: find N/D of total
+      const denom = denominators[randomInt(0, denominators.length - 1)];
+      const numer = randomInt(1, denom - 1);
+      const multiplierRange = getGradeRange(
+        grade,
+        { min: 2, max: 5 },
+        { min: 3, max: 10 },
+        { min: 5, max: 20 }
+      );
+      const multiplier = randomInt(multiplierRange.min, multiplierRange.max);
+      const total = denom * multiplier;
+      const answer = numer * multiplier;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'multiplication' as Operation,
+        problemText: `${name} has ${total} ${item}. What is ${numer}/${denom} of the ${item}?`,
+        answer,
+        category: 'fraction-set',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Equivalent fractions: find missing numerator or denominator
+      const denom1 = denominators[randomInt(0, denominators.length - 1)];
+      const numer1 = randomInt(1, denom1 - 1);
+      const scale = randomInt(2, grade <= 4 ? 4 : 6);
+      const denom2 = denom1 * scale;
+      const numer2 = numer1 * scale;
+      const askNumerator = randomInt(0, 1) === 1;
+
+      if (askNumerator) {
+        problems.push({
+          id: generateId(),
+          type: 'singapore',
+          operation: 'multiplication' as Operation,
+          problemText: `Find the missing number: ${numer1}/${denom1} = ?/${denom2}`,
+          answer: numer2,
+          category: 'fraction-set',
+          showCalculation: true,
+          language: 'en',
+        });
+      } else {
+        problems.push({
+          id: generateId(),
+          type: 'singapore',
+          operation: 'multiplication' as Operation,
+          problemText: `Find the missing number: ${numer1}/${denom1} = ${numer2}/?`,
+          answer: denom2,
+          category: 'fraction-set',
+          showCalculation: true,
+          language: 'en',
+        });
+      }
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-fraction-set'));
+  return problems;
+}
+
+/**
+ * Decimal addition and subtraction word problems (Primary 4+).
+ */
+export function generateSingaporeDecimal(
+  grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const names = ['Aiden', 'Maya', 'Noah', 'Emma', 'Liam', 'Zoe'];
+  const contexts: Array<{ item: string; unit: string }> = [
+    { item: 'water', unit: 'litres' },
+    { item: 'ribbon', unit: 'metres' },
+    { item: 'flour', unit: 'kg' },
+    { item: 'rope', unit: 'metres' },
+    { item: 'juice', unit: 'litres' },
+  ];
+
+  for (let i = 0; i < count; i++) {
+    const ctx = contexts[randomInt(0, contexts.length - 1)];
+    const nameA = names[randomInt(0, names.length - 1)];
+    const nameB = pickDifferentName(names, nameA);
+    const isAddition = randomInt(0, 1) === 1;
+
+    // Generate decimals with 1 or 2 decimal places
+    const places = grade <= 4 ? 1 : randomInt(1, 2);
+    const factor = places === 1 ? 10 : 100;
+    const maxRange = getGradeRange(
+      grade,
+      { min: 20, max: 50 },
+      { min: 30, max: 100 },
+      { min: 50, max: 200 }
+    );
+
+    if (isAddition) {
+      const aInt = randomInt(10, maxRange.max);
+      const bInt = randomInt(10, maxRange.max);
+      const a = aInt / factor;
+      const b = bInt / factor;
+      const answer = Math.round((a + b) * factor) / factor;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'addition' as Operation,
+        problemText: `${nameA} has ${a} ${ctx.unit} of ${ctx.item}. ${nameB} has ${b} ${ctx.unit}. How many ${ctx.unit} do they have altogether?`,
+        answer,
+        category: 'decimal',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      const bInt = randomInt(10, Math.floor(maxRange.max * 0.6));
+      const aInt = bInt + randomInt(5, Math.floor(maxRange.max * 0.4));
+      const a = aInt / factor;
+      const b = bInt / factor;
+      const answer = Math.round((a - b) * factor) / factor;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'subtraction' as Operation,
+        problemText: `${nameA} has ${a} ${ctx.unit} of ${ctx.item}. ${nameA} gives ${b} ${ctx.unit} to ${nameB}. How many ${ctx.unit} does ${nameA} have left?`,
+        answer,
+        category: 'decimal',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-decimal'));
+  return problems;
+}
+
+// ── Grade 5+ generators ──────────────────────────────────────────────
+
+/**
+ * Ratio and proportion problems (Primary 5+).
+ */
+export function generateSingaporeRatio(
+  grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const names = ['Ryan', 'Chloe', 'Ethan', 'Sofia', 'Lucas', 'Mia'];
+  const items = ['marbles', 'stickers', 'beads', 'cards', 'stamps'];
+
+  for (let i = 0; i < count; i++) {
+    const item = items[randomInt(0, items.length - 1)];
+    const nameA = names[randomInt(0, names.length - 1)];
+    const nameB = pickDifferentName(names, nameA);
+    const problemType = randomInt(0, 2);
+
+    if (problemType === 0) {
+      // Given ratio and one quantity, find the other
+      const ratioA = randomInt(2, grade <= 5 ? 5 : 8);
+      const ratioB = randomInt(2, grade <= 5 ? 5 : 8);
+      const multiplier = randomInt(2, grade <= 5 ? 6 : 10);
+      const quantityA = ratioA * multiplier;
+      const quantityB = ratioB * multiplier;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'multiplication' as Operation,
+        problemText: `The ratio of ${nameA}'s ${item} to ${nameB}'s ${item} is ${ratioA} : ${ratioB}. If ${nameA} has ${quantityA} ${item}, how many does ${nameB} have?`,
+        answer: quantityB,
+        category: 'ratio',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else if (problemType === 1) {
+      // Given ratio and total, find one quantity
+      const ratioA = randomInt(2, 5);
+      const ratioB = randomInt(2, 5);
+      const multiplier = randomInt(3, grade <= 5 ? 8 : 12);
+      const total = (ratioA + ratioB) * multiplier;
+      const quantityA = ratioA * multiplier;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `${nameA} and ${nameB} share ${total} ${item} in the ratio ${ratioA} : ${ratioB}. How many ${item} does ${nameA} get?`,
+        answer: quantityA,
+        category: 'ratio',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Simplify a ratio
+      const gcdBase = randomInt(2, grade <= 5 ? 5 : 8);
+      const a = randomInt(2, 5);
+      const b = randomInt(2, 5);
+      const bigA = a * gcdBase;
+      const bigB = b * gcdBase;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `Simplify the ratio ${bigA} : ${bigB}. What is the first term in the simplest form?`,
+        answer: a,
+        category: 'ratio',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-ratio'));
+  return problems;
+}
+
+/**
+ * Percentage problems (Primary 5+).
+ */
+export function generateSingaporePercentage(
+  grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const names = ['Aiden', 'Maya', 'Noah', 'Emma', 'Liam', 'Zoe'];
+
+  const percentages =
+    grade <= 5
+      ? [10, 20, 25, 50, 75]
+      : [5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 80];
+
+  for (let i = 0; i < count; i++) {
+    const name = names[randomInt(0, names.length - 1)];
+    const problemType = randomInt(0, 1);
+
+    if (problemType === 0) {
+      // Find X% of a number
+      const percent = percentages[randomInt(0, percentages.length - 1)];
+      // Ensure whole number answer: total must be divisible by (100/gcd(percent,100))
+      const base = 100 / gcd(percent, 100);
+      const multiplier = randomInt(grade <= 5 ? 1 : 2, grade <= 5 ? 8 : 15);
+      const total = base * multiplier;
+      const answer = (total * percent) / 100;
+
+      const contexts = [
+        `${name} scored ${percent}% on a test with ${total} questions. How many questions did ${name} get right?`,
+        `A shop gives a ${percent}% discount on a $${total} item. How much is the discount?`,
+        `${name} saved ${percent}% of $${total}. How much did ${name} save?`,
+      ];
+      const text = contexts[randomInt(0, contexts.length - 1)];
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'multiplication' as Operation,
+        problemText: text,
+        answer,
+        category: 'percentage',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Find what percentage one number is of another
+      const total = randomInt(grade <= 5 ? 20 : 40, grade <= 5 ? 100 : 200);
+      const percent = percentages[randomInt(0, percentages.length - 1)];
+      const part = (total * percent) / 100;
+      if (!Number.isInteger(part) || part <= 0) {
+        i--;
+        continue;
+      }
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `${name} answered ${part} out of ${total} questions correctly. What percentage is that?`,
+        answer: percent,
+        category: 'percentage',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-percentage'));
+  return problems;
+}
+
+function gcd(a: number, b: number): number {
+  while (b) {
+    [a, b] = [b, a % b];
+  }
+  return a;
+}
+
+/**
+ * Speed, distance, and time problems (Primary 5+).
+ */
+export function generateSingaporeRate(
+  grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const names = ['Ryan', 'Chloe', 'Ethan', 'Sofia', 'Lucas', 'Mia'];
+  const vehicles = ['car', 'bus', 'train', 'bicycle', 'van'];
+
+  for (let i = 0; i < count; i++) {
+    const name = names[randomInt(0, names.length - 1)];
+    const vehicle = vehicles[randomInt(0, vehicles.length - 1)];
+    const problemType = randomInt(0, 2);
+
+    if (problemType === 0) {
+      // Find distance: d = s × t
+      const speed = randomInt(grade <= 5 ? 30 : 40, grade <= 5 ? 80 : 120);
+      const hours = randomInt(2, grade <= 5 ? 5 : 8);
+      const distance = speed * hours;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'multiplication' as Operation,
+        problemText: `A ${vehicle} travels at ${speed} km/h. How far does it travel in ${hours} hours?`,
+        answer: distance,
+        category: 'rate',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else if (problemType === 1) {
+      // Find time: t = d / s
+      const speed = randomInt(grade <= 5 ? 30 : 40, grade <= 5 ? 80 : 100);
+      const hours = randomInt(2, grade <= 5 ? 6 : 8);
+      const distance = speed * hours;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `${name} drives a ${vehicle} at ${speed} km/h. How many hours does it take to travel ${distance} km?`,
+        answer: hours,
+        category: 'rate',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Find speed: s = d / t
+      const hours = randomInt(2, grade <= 5 ? 5 : 8);
+      const speed = randomInt(grade <= 5 ? 30 : 40, grade <= 5 ? 80 : 120);
+      const distance = speed * hours;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `A ${vehicle} travels ${distance} km in ${hours} hours. What is its speed in km/h?`,
+        answer: speed,
+        category: 'rate',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-rate'));
+  return problems;
+}
+
+/**
+ * Volume of rectangular prism problems (Primary 5+).
+ */
+export function generateSingaporeVolume(
+  grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const problemType = randomInt(0, 1);
+    const maxDim = grade <= 5 ? 12 : 20;
+
+    if (problemType === 0) {
+      // Find volume: V = l × w × h
+      const length = randomInt(2, maxDim);
+      const width = randomInt(2, maxDim);
+      const height = randomInt(2, maxDim);
+      const volume = length * width * height;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'multiplication' as Operation,
+        problemText: `A rectangular tank is ${length} cm long, ${width} cm wide and ${height} cm tall. What is its volume in cm³?`,
+        answer: volume,
+        category: 'volume',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Find missing dimension: given V and 2 dims
+      const length = randomInt(2, maxDim);
+      const width = randomInt(2, maxDim);
+      const height = randomInt(2, maxDim);
+      const volume = length * width * height;
+      const dimToHide = randomInt(0, 2);
+
+      let text: string;
+      let answer: number;
+      if (dimToHide === 0) {
+        text = `A rectangular box has a volume of ${volume} cm³. Its width is ${width} cm and its height is ${height} cm. What is its length?`;
+        answer = length;
+      } else if (dimToHide === 1) {
+        text = `A rectangular box has a volume of ${volume} cm³. Its length is ${length} cm and its height is ${height} cm. What is its width?`;
+        answer = width;
+      } else {
+        text = `A rectangular box has a volume of ${volume} cm³. Its length is ${length} cm and its width is ${width} cm. What is its height?`;
+        answer = height;
+      }
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: text,
+        answer,
+        category: 'volume',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-volume'));
+  return problems;
+}
+
+// ── Grade 6 generators ───────────────────────────────────────────────
+
+/**
+ * Simple algebra / linear equation problems (Primary 6).
+ */
+export function generateSingaporeAlgebra(
+  grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const names = ['Aiden', 'Maya', 'Noah', 'Emma', 'Liam', 'Zoe'];
+
+  for (let i = 0; i < count; i++) {
+    const problemType = randomInt(0, 2);
+
+    if (problemType === 0) {
+      // Solve ax + b = c
+      const a = randomInt(2, grade <= 5 ? 5 : 9);
+      const x = randomInt(2, grade <= 5 ? 10 : 15);
+      const b = randomInt(1, grade <= 5 ? 10 : 20);
+      const c = a * x + b;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `Solve for x: ${a}x + ${b} = ${c}`,
+        answer: x,
+        category: 'algebra',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else if (problemType === 1) {
+      // Solve ax - b = c
+      const a = randomInt(2, 8);
+      const x = randomInt(3, 15);
+      const b = randomInt(1, a * x - 1);
+      const c = a * x - b;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `Solve for x: ${a}x − ${b} = ${c}`,
+        answer: x,
+        category: 'algebra',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Word problem → equation
+      const name = names[randomInt(0, names.length - 1)];
+      const x = randomInt(3, 12);
+      const groups = randomInt(2, 6);
+      const extra = randomInt(1, 10);
+      const total = groups * x + extra;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `${name} buys ${groups} identical notebooks and a pen that costs $${extra}. The total cost is $${total}. How much does each notebook cost?`,
+        answer: x,
+        category: 'algebra',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-algebra'));
+  return problems;
+}
+
+/**
+ * Advanced ratio problems with before/after changes (Primary 6).
+ */
+export function generateSingaporeRatioAdvanced(
+  _grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const names = ['Ryan', 'Chloe', 'Ethan', 'Sofia', 'Lucas', 'Mia'];
+  const items = ['marbles', 'stickers', 'beads', 'cards', 'stamps'];
+
+  for (let i = 0; i < count; i++) {
+    const item = items[randomInt(0, items.length - 1)];
+    const nameA = names[randomInt(0, names.length - 1)];
+    const nameB = pickDifferentName(names, nameA);
+    const problemType = randomInt(0, 1);
+
+    if (problemType === 0) {
+      // Before/after: one person gives some to another
+      const ratioA = randomInt(3, 7);
+      const ratioB = randomInt(2, ratioA - 1);
+      const multiplier = randomInt(2, 8);
+      const quantityA = ratioA * multiplier;
+      const quantityB = ratioB * multiplier;
+      const transfer = randomInt(
+        1,
+        Math.min(quantityA - 1, Math.floor(quantityA * 0.3))
+      );
+      const newB = quantityB + transfer;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'subtraction' as Operation,
+        problemText: `The ratio of ${nameA}'s ${item} to ${nameB}'s ${item} is ${ratioA} : ${ratioB}. ${nameA} gives ${transfer} ${item} to ${nameB}. If ${nameA} had ${quantityA} ${item} at first, how many does ${nameB} have now?`,
+        answer: newB,
+        category: 'ratio-advanced',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Total stays the same, ratio changes
+      const ratioA1 = randomInt(3, 6);
+      const ratioB1 = randomInt(2, 5);
+      const totalParts1 = ratioA1 + ratioB1;
+      const multiplier = randomInt(2, 8);
+      const total = totalParts1 * multiplier;
+      const quantityA = ratioA1 * multiplier;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `${nameA} and ${nameB} have ${total} ${item} altogether. The ratio of ${nameA}'s ${item} to ${nameB}'s ${item} is ${ratioA1} : ${ratioB1}. How many ${item} does ${nameA} have?`,
+        answer: quantityA,
+        category: 'ratio-advanced',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-ratio-advanced'));
+  return problems;
+}
+
+/**
+ * Circle circumference and area problems (Primary 6).
+ * Uses π = 3.14 as per Singapore P6 curriculum.
+ */
+export function generateSingaporeCircle(
+  grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const PI = 3.14;
+
+  for (let i = 0; i < count; i++) {
+    const problemType = randomInt(0, 2);
+    const radius = randomInt(2, grade <= 5 ? 10 : 20);
+    const diameter = radius * 2;
+
+    if (problemType === 0) {
+      // Find circumference from radius
+      const circumference = Math.round(2 * PI * radius * 100) / 100;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'multiplication' as Operation,
+        problemText: `A circle has a radius of ${radius} cm. Find its circumference. (Use π = 3.14)`,
+        answer: circumference,
+        category: 'circle',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else if (problemType === 1) {
+      // Find circumference from diameter
+      const circumference = Math.round(PI * diameter * 100) / 100;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'multiplication' as Operation,
+        problemText: `A circle has a diameter of ${diameter} cm. Find its circumference. (Use π = 3.14)`,
+        answer: circumference,
+        category: 'circle',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Find area from radius
+      const area = Math.round(PI * radius * radius * 100) / 100;
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'multiplication' as Operation,
+        problemText: `A circle has a radius of ${radius} cm. Find its area. (Use π = 3.14)`,
+        answer: area,
+        category: 'circle',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-circle'));
+  return problems;
+}
+
+/**
+ * Data analysis: mean, median, mode (Primary 6).
+ */
+export function generateSingaporeDataAnalysis(
+  _grade: Grade,
+  count: number
+): SingaporeProblem[] {
+  const problems: SingaporeProblem[] = [];
+  const contexts = [
+    'test scores',
+    'heights in cm',
+    'weights in kg',
+    'points scored',
+    'temperatures in °C',
+  ];
+
+  for (let i = 0; i < count; i++) {
+    const context = contexts[randomInt(0, contexts.length - 1)];
+    const problemType = randomInt(0, 2);
+    const dataSize = randomInt(5, 7);
+
+    if (problemType === 0) {
+      // Find mean (ensure integer mean)
+      const targetMean = randomInt(10, 50);
+      const data: number[] = [];
+      let sum = 0;
+      for (let j = 0; j < dataSize - 1; j++) {
+        const val = targetMean + randomInt(-10, 10);
+        data.push(val);
+        sum += val;
+      }
+      const lastVal = targetMean * dataSize - sum;
+      data.push(lastVal);
+
+      // Shuffle data
+      for (let j = data.length - 1; j > 0; j--) {
+        const k = randomInt(0, j);
+        [data[j], data[k]] = [data[k], data[j]];
+      }
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'division' as Operation,
+        problemText: `Find the mean of these ${context}: ${data.join(', ')}.`,
+        answer: targetMean,
+        category: 'data-analysis',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else if (problemType === 1) {
+      // Find median (odd count ensures unique median)
+      const oddSize = dataSize % 2 === 0 ? dataSize + 1 : dataSize;
+      const data: number[] = [];
+      for (let j = 0; j < oddSize; j++) {
+        data.push(randomInt(10, 60));
+      }
+      const sorted = [...data].sort((a, b) => a - b);
+      const median = sorted[Math.floor(oddSize / 2)];
+
+      // Shuffle data for presentation
+      for (let j = data.length - 1; j > 0; j--) {
+        const k = randomInt(0, j);
+        [data[j], data[k]] = [data[k], data[j]];
+      }
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'addition' as Operation,
+        problemText: `Find the median of these ${context}: ${data.join(', ')}.`,
+        answer: median,
+        category: 'data-analysis',
+        showCalculation: true,
+        language: 'en',
+      });
+    } else {
+      // Find mode: ensure a clear mode exists
+      const baseVal = randomInt(10, 50);
+      const data: number[] = [baseVal, baseVal, baseVal]; // mode appears 3 times
+      for (let j = 3; j < dataSize; j++) {
+        let val = baseVal + randomInt(1, 20);
+        // Ensure no other value repeats 3+ times
+        while (data.filter((d) => d === val).length >= 2) {
+          val = baseVal + randomInt(1, 20);
+        }
+        data.push(val);
+      }
+
+      // Shuffle
+      for (let j = data.length - 1; j > 0; j--) {
+        const k = randomInt(0, j);
+        [data[j], data[k]] = [data[k], data[j]];
+      }
+
+      problems.push({
+        id: generateId(),
+        type: 'singapore',
+        operation: 'addition' as Operation,
+        problemText: `Find the mode of these ${context}: ${data.join(', ')}.`,
+        answer: baseVal,
+        category: 'data-analysis',
+        showCalculation: true,
+        language: 'en',
+      });
+    }
+  }
+
+  problems.forEach((p) => assertValidProblem(p, 'singapore-data-analysis'));
+  return problems;
+}

--- a/src/lib/generators/singapore-problems-en.ts
+++ b/src/lib/generators/singapore-problems-en.ts
@@ -914,13 +914,16 @@ export function generateSingaporeRatio(
       const b = randomInt(2, 5);
       const bigA = a * gcdBase;
       const bigB = b * gcdBase;
+      // a and b may share a common factor, so reduce to true simplest form
+      const commonFactor = gcd(a, b);
+      const simplifiedA = a / commonFactor;
 
       problems.push({
         id: generateId(),
         type: 'singapore',
         operation: 'division' as Operation,
         problemText: `Simplify the ratio ${bigA} : ${bigB}. What is the first term in the simplest form?`,
-        answer: a,
+        answer: simplifiedA,
         category: 'ratio',
         showCalculation: true,
         language: 'en',
@@ -979,13 +982,12 @@ export function generateSingaporePercentage(
       });
     } else {
       // Find what percentage one number is of another
-      const total = randomInt(grade <= 5 ? 20 : 40, grade <= 5 ? 100 : 200);
+      // Constructive: pick percent, compute base that guarantees integer part
       const percent = percentages[randomInt(0, percentages.length - 1)];
+      const base = 100 / gcd(percent, 100);
+      const multiplier = randomInt(grade <= 5 ? 1 : 2, grade <= 5 ? 5 : 10);
+      const total = base * multiplier;
       const part = (total * percent) / 100;
-      if (!Number.isInteger(part) || part <= 0) {
-        i--;
-        continue;
-      }
 
       problems.push({
         id: generateId(),
@@ -1114,24 +1116,16 @@ export function generateSingaporeVolume(
       });
     } else {
       // Find missing dimension: given V and 2 dims
-      const length = randomInt(2, maxDim);
-      const width = randomInt(2, maxDim);
-      const height = randomInt(2, maxDim);
-      const volume = length * width * height;
-      const dimToHide = randomInt(0, 2);
-
-      let text: string;
-      let answer: number;
-      if (dimToHide === 0) {
-        text = `A rectangular box has a volume of ${volume} cm³. Its width is ${width} cm and its height is ${height} cm. What is its length?`;
-        answer = length;
-      } else if (dimToHide === 1) {
-        text = `A rectangular box has a volume of ${volume} cm³. Its length is ${length} cm and its height is ${height} cm. What is its width?`;
-        answer = width;
-      } else {
-        text = `A rectangular box has a volume of ${volume} cm³. Its length is ${length} cm and its width is ${width} cm. What is its height?`;
-        answer = height;
-      }
+      const dims = [
+        { name: 'length', value: randomInt(2, maxDim) },
+        { name: 'width', value: randomInt(2, maxDim) },
+        { name: 'height', value: randomInt(2, maxDim) },
+      ];
+      const volume = dims[0].value * dims[1].value * dims[2].value;
+      const hiddenIdx = randomInt(0, 2);
+      const shown = dims.filter((_, idx) => idx !== hiddenIdx);
+      const text = `A rectangular box has a volume of ${volume} cm³. Its ${shown[0].name} is ${shown[0].value} cm and its ${shown[1].name} is ${shown[1].value} cm. What is its ${dims[hiddenIdx].name}?`;
+      const answer = dims[hiddenIdx].value;
 
       problems.push({
         id: generateId(),
@@ -1156,7 +1150,7 @@ export function generateSingaporeVolume(
  * Simple algebra / linear equation problems (Primary 6).
  */
 export function generateSingaporeAlgebra(
-  grade: Grade,
+  _grade: Grade,
   count: number
 ): SingaporeProblem[] {
   const problems: SingaporeProblem[] = [];
@@ -1167,9 +1161,9 @@ export function generateSingaporeAlgebra(
 
     if (problemType === 0) {
       // Solve ax + b = c
-      const a = randomInt(2, grade <= 5 ? 5 : 9);
-      const x = randomInt(2, grade <= 5 ? 10 : 15);
-      const b = randomInt(1, grade <= 5 ? 10 : 20);
+      const a = randomInt(2, 9);
+      const x = randomInt(2, 15);
+      const b = randomInt(1, 20);
       const c = a * x + b;
 
       problems.push({
@@ -1295,7 +1289,7 @@ export function generateSingaporeRatioAdvanced(
  * Uses π = 3.14 as per Singapore P6 curriculum.
  */
 export function generateSingaporeCircle(
-  grade: Grade,
+  _grade: Grade,
   count: number
 ): SingaporeProblem[] {
   const problems: SingaporeProblem[] = [];
@@ -1303,7 +1297,7 @@ export function generateSingaporeCircle(
 
   for (let i = 0; i < count; i++) {
     const problemType = randomInt(0, 2);
-    const radius = randomInt(2, grade <= 5 ? 10 : 20);
+    const radius = randomInt(2, 20);
     const diameter = radius * 2;
 
     if (problemType === 0) {
@@ -1355,6 +1349,13 @@ export function generateSingaporeCircle(
   return problems;
 }
 
+function shuffleArray(arr: number[]): void {
+  for (let j = arr.length - 1; j > 0; j--) {
+    const k = randomInt(0, j);
+    [arr[j], arr[k]] = [arr[k], arr[j]];
+  }
+}
+
 /**
  * Data analysis: mean, median, mode (Primary 6).
  */
@@ -1377,23 +1378,23 @@ export function generateSingaporeDataAnalysis(
     const dataSize = randomInt(5, 7);
 
     if (problemType === 0) {
-      // Find mean (ensure integer mean)
+      // Find mean (ensure integer mean with all values in reasonable range)
       const targetMean = randomInt(10, 50);
-      const data: number[] = [];
-      let sum = 0;
-      for (let j = 0; j < dataSize - 1; j++) {
-        const val = targetMean + randomInt(-10, 10);
-        data.push(val);
-        sum += val;
-      }
-      const lastVal = targetMean * dataSize - sum;
+      let data: number[];
+      let lastVal: number;
+      do {
+        data = [];
+        let sum = 0;
+        for (let j = 0; j < dataSize - 1; j++) {
+          const val = targetMean + randomInt(-5, 5);
+          data.push(val);
+          sum += val;
+        }
+        lastVal = targetMean * dataSize - sum;
+      } while (lastVal < 1 || lastVal > 99);
       data.push(lastVal);
 
-      // Shuffle data
-      for (let j = data.length - 1; j > 0; j--) {
-        const k = randomInt(0, j);
-        [data[j], data[k]] = [data[k], data[j]];
-      }
+      shuffleArray(data);
 
       problems.push({
         id: generateId(),
@@ -1415,11 +1416,7 @@ export function generateSingaporeDataAnalysis(
       const sorted = [...data].sort((a, b) => a - b);
       const median = sorted[Math.floor(oddSize / 2)];
 
-      // Shuffle data for presentation
-      for (let j = data.length - 1; j > 0; j--) {
-        const k = randomInt(0, j);
-        [data[j], data[k]] = [data[k], data[j]];
-      }
+      shuffleArray(data);
 
       problems.push({
         id: generateId(),
@@ -1444,11 +1441,7 @@ export function generateSingaporeDataAnalysis(
         data.push(val);
       }
 
-      // Shuffle
-      for (let j = data.length - 1; j > 0; j--) {
-        const k = randomInt(0, j);
-        [data[j], data[k]] = [data[k], data[j]];
-      }
+      shuffleArray(data);
 
       problems.push({
         id: generateId(),

--- a/src/types/calculation-patterns.ts
+++ b/src/types/calculation-patterns.ts
@@ -76,6 +76,16 @@ export type CalculationPattern =
   | 'singapore-number-bond' // Singapore Math: number bond decomposition
   | 'singapore-comparison' // Singapore Math: grade-aware comparison
   | 'singapore-multi-step' // Singapore Math: multi-step with fractions
+  | 'singapore-fraction-set' // Singapore Math: fraction of a set (P4)
+  | 'singapore-decimal' // Singapore Math: decimal word problems (P4)
+  | 'singapore-ratio' // Singapore Math: ratio and proportion (P5)
+  | 'singapore-percentage' // Singapore Math: percentage (P5)
+  | 'singapore-rate' // Singapore Math: speed, distance, time (P5)
+  | 'singapore-volume' // Singapore Math: rectangular prism volume (P5)
+  | 'singapore-algebra' // Singapore Math: simple equations (P6)
+  | 'singapore-ratio-advanced' // Singapore Math: before/after ratio (P6)
+  | 'singapore-circle' // Singapore Math: circumference and area (P6)
+  | 'singapore-data-analysis' // Singapore Math: mean, median, mode (P6)
 
   // お金の計算（1-4年生）
   | 'money-change-jap' // おつりの計算（日本円）
@@ -347,6 +357,8 @@ export const PATTERNS_BY_GRADE: Record<number, CalculationPattern[]> = {
     'singapore-number-bond',
     'singapore-comparison',
     'singapore-multi-step',
+    'singapore-fraction-set',
+    'singapore-decimal',
     'time-reading-jap',
     'time-elapsed-jap',
     'time-calc-jap',
@@ -421,6 +433,12 @@ export const PATTERNS_BY_GRADE: Record<number, CalculationPattern[]> = {
     'singapore-number-bond',
     'singapore-comparison',
     'singapore-multi-step',
+    'singapore-fraction-set',
+    'singapore-decimal',
+    'singapore-ratio',
+    'singapore-percentage',
+    'singapore-rate',
+    'singapore-volume',
     'unit-length-jap',
     'unit-weight-jap',
     'unit-capacity-jap',
@@ -479,6 +497,16 @@ export const PATTERNS_BY_GRADE: Record<number, CalculationPattern[]> = {
     'singapore-number-bond',
     'singapore-comparison',
     'singapore-multi-step',
+    'singapore-fraction-set',
+    'singapore-decimal',
+    'singapore-ratio',
+    'singapore-percentage',
+    'singapore-rate',
+    'singapore-volume',
+    'singapore-algebra',
+    'singapore-ratio-advanced',
+    'singapore-circle',
+    'singapore-data-analysis',
     'unit-length-jap',
     'unit-weight-jap',
     'unit-capacity-jap',
@@ -608,6 +636,16 @@ export const PATTERN_LABELS: Record<CalculationPattern, string> = {
   'singapore-number-bond': 'Singapore Math: Number Bond',
   'singapore-comparison': 'Singapore Math: Comparison',
   'singapore-multi-step': 'Singapore Math: Multi-step Fractions',
+  'singapore-fraction-set': 'Singapore Math: Fraction of a Set',
+  'singapore-decimal': 'Singapore Math: Decimals',
+  'singapore-ratio': 'Singapore Math: Ratio',
+  'singapore-percentage': 'Singapore Math: Percentage',
+  'singapore-rate': 'Singapore Math: Speed/Distance/Time',
+  'singapore-volume': 'Singapore Math: Volume',
+  'singapore-algebra': 'Singapore Math: Algebra',
+  'singapore-ratio-advanced': 'Singapore Math: Advanced Ratio',
+  'singapore-circle': 'Singapore Math: Circle',
+  'singapore-data-analysis': 'Singapore Math: Data Analysis',
 
   // お金の計算
   'money-change-jap': 'おつりの計算',
@@ -793,6 +831,23 @@ export const PATTERN_DESCRIPTIONS: Record<CalculationPattern, string> = {
     'Comparison problems using "more/fewer than" in grade 2 and "times as many" in grade 3+',
   'singapore-multi-step':
     'Multi-step Singapore style word problems with fraction reasoning',
+  'singapore-fraction-set':
+    'Find a fraction of a set or identify equivalent fractions (Primary 4+)',
+  'singapore-decimal':
+    'Word problems involving addition and subtraction of decimals (Primary 4+)',
+  'singapore-ratio': 'Simple ratio and proportion problems (Primary 5+)',
+  'singapore-percentage':
+    'Finding percentage of a number or what percentage one number is of another (Primary 5+)',
+  'singapore-rate': 'Speed, distance and time word problems (Primary 5+)',
+  'singapore-volume':
+    'Rectangular prism volume calculations with missing dimensions (Primary 5+)',
+  'singapore-algebra':
+    'Simple algebraic expressions and linear equations (Primary 6)',
+  'singapore-ratio-advanced': 'Before/after ratio change problems (Primary 6)',
+  'singapore-circle':
+    'Circumference and area of circles using π = 3.14 (Primary 6)',
+  'singapore-data-analysis':
+    'Finding mean, median or mode from a data set (Primary 6)',
 
   // お金の計算
   'money-change-jap': '100円で68円のお菓子を買ったら、おつりはいくら？',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -189,7 +189,21 @@ export interface SingaporeProblem {
   problemText: string;
   answer: number | string;
   unit?: string;
-  category: 'bar-model' | 'number-bond' | 'comparison' | 'multi-step';
+  category:
+    | 'bar-model'
+    | 'number-bond'
+    | 'comparison'
+    | 'multi-step'
+    | 'fraction-set'
+    | 'decimal'
+    | 'ratio'
+    | 'percentage'
+    | 'rate'
+    | 'volume'
+    | 'algebra'
+    | 'ratio-advanced'
+    | 'circle'
+    | 'data-analysis';
   diagram?: SingaporeDiagram;
   showCalculation?: boolean;
   language: 'en';


### PR DESCRIPTION
## Summary

- Add 10 new Singapore Math problem patterns covering Grade 4-6 (Primary 4-6) curriculum
- Grade 4: fraction-of-a-set, decimal word problems
- Grade 5: ratio, percentage, speed/distance/time, volume
- Grade 6: algebra, advanced ratio, circle (π=3.14), data analysis (mean/median/mode)
- All generators follow established patterns with `assertValidProblem` validation

Closes #49

## Changes

| File | Change |
|---|---|
| `src/lib/generators/singapore-problems-en.ts` | 10 new generator functions (+773 lines) |
| `src/lib/generators/singapore-problems-en.test.ts` | Property-based tests (200+ samples each), math verification, name-uniqueness checks |
| `src/types/calculation-patterns.ts` | 10 new pattern IDs, PATTERNS_BY_GRADE, labels, descriptions |
| `src/types/index.ts` | Extended SingaporeProblem category union |
| `src/lib/generators/patterns/index.ts` | 10 new case statements in router |
| `src/config/problem-patterns.ts` | Added to SINGAPORE_MATH_PATTERNS |
| `src/config/pattern-categories.ts` | Added BASE_DIFFICULTY entries |
| `src/config/print-templates.ts` | Added recommendedCounts/maxCounts |
| `scripts/verify-singapore-playwright.mjs` | Added grade 4-6 verification combos |

## Test plan

- [x] All 630 tests pass (`npm test -- --run`)
- [x] Lint clean (`npm run lint`)
- [x] Type check clean (`npm run typecheck`)
- [x] Build successful (`npm run build`)
- [ ] Playwright visual verification for each new pattern/grade combo
- [ ] Print layout check for A4 rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)