### PR TITLE
fix(hissan): 3桁×2桁のかけ算が2枚に分かれる問題と横線の幅を修正

### DIFF
--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -57,7 +57,7 @@ import {
   hissanCellStyle,
   hissanAnswerBoxStyle,
   getHissanLineStyle,
-  HISSAN_ANSWER_GAP,
+  hissanRowStyle,
   SPACING,
 } from '../../config/styles';
 
@@ -248,14 +248,7 @@ const HissanAnswerRow: React.FC<{
   answerDigits: string[];
   showAnswer: boolean;
 }> = ({ answerWidth, answerDigits, showAnswer }) => (
-  <div
-    style={{
-      whiteSpace: 'nowrap',
-      display: 'flex',
-      gap: `${HISSAN_ANSWER_GAP}px`,
-      justifyContent: 'flex-end',
-    }}
-  >
+  <div style={hissanRowStyle}>
     {showAnswer ? (
       <>
         {Array(Math.max(answerWidth - answerDigits.length, 0))
@@ -299,7 +292,7 @@ const PartialProductBoxes: React.FC<{
         const rightPad = idx;
         const leftPad = totalWidth - partialWidth - rightPad;
         return (
-          <div key={`partial-${idx}`} style={{ whiteSpace: 'nowrap' }}>
+          <div key={`partial-${idx}`} style={hissanRowStyle}>
             {Array(Math.max(leftPad, 0))
               .fill('')
               .map((_, i) => (
@@ -635,7 +628,7 @@ function ProblemItem({
         <div style={problemNumberStyle}>({number})</div>
         <div style={hissanContainerStyle}>
           {/* 1つ目の数 */}
-          <div style={{ whiteSpace: 'nowrap' }}>
+          <div style={hissanRowStyle}>
             {paddedDigits1.map((d, i) => (
               <span key={i} style={hissanCellStyle}>
                 {d === '' ? '\u00A0' : d}
@@ -644,7 +637,7 @@ function ProblemItem({
           </div>
 
           {/* 演算子と2つ目の数 */}
-          <div style={{ whiteSpace: 'nowrap' }}>
+          <div style={hissanRowStyle}>
             {/* 演算子を数字の左に配置（digits2の長さに応じて左側にパディング） */}
             {Array(maxLength - digits2.length)
               .fill('')

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -289,7 +289,8 @@ const HissanAnswerRow: React.FC<{
 const PartialProductBoxes: React.FC<{
   digits1Length: number;
   digits2Length: number;
-}> = ({ digits1Length, digits2Length }) => {
+  lineBoxCount: number;
+}> = ({ digits1Length, digits2Length, lineBoxCount }) => {
   const partialWidth = digits1Length + 1;
   const totalWidth = digits1Length + digits2Length;
   return (
@@ -321,7 +322,7 @@ const PartialProductBoxes: React.FC<{
           </div>
         );
       })}
-      <div style={getHissanLineStyle(totalWidth)} />
+      <div style={getHissanLineStyle(lineBoxCount - 1)} />
     </>
   );
 };
@@ -622,6 +623,13 @@ function ProblemItem({
         ? hissanProblem.answer.toString().split('')
         : [];
 
+    // 答え行の桁数（かけ算は digits1+digits2、それ以外は maxLength+1）
+    // 横線は答え行と同じ幅に揃える
+    const answerWidth =
+      hissanProblem.operation === 'multiplication'
+        ? digits1.length + digits2.length
+        : maxLength + 1;
+
     return (
       <div className="problem-text" style={problemItemStyle}>
         <div style={problemNumberStyle}>({number})</div>
@@ -653,8 +661,8 @@ function ProblemItem({
             ))}
           </div>
 
-          {/* 横線 */}
-          <div style={getHissanLineStyle(maxLength)} />
+          {/* 横線（答え行と同じ幅に揃える） */}
+          <div style={getHissanLineStyle(answerWidth - 1)} />
 
           {/* 多桁乗算の部分積記入欄（digits2 が 2 桁以上のかけ算のみ） */}
           {hissanProblem.operation === 'multiplication' &&
@@ -663,16 +671,13 @@ function ProblemItem({
               <PartialProductBoxes
                 digits1Length={digits1.length}
                 digits2Length={digits2.length}
+                lineBoxCount={answerWidth}
               />
             )}
 
-          {/* 答え（かけ算は最大 digits1+digits2 桁、それ以外は maxLength+1 桁） */}
+          {/* 答え */}
           <HissanAnswerRow
-            answerWidth={
-              hissanProblem.operation === 'multiplication'
-                ? digits1.length + digits2.length
-                : maxLength + 1
-            }
+            answerWidth={answerWidth}
             answerDigits={answerDigits}
             showAnswer={showAnswer && !!hissanProblem.answer}
           />

--- a/src/config/print-templates.ts
+++ b/src/config/print-templates.ts
@@ -215,12 +215,13 @@ export const PRINT_TEMPLATES = {
     type: 'hissan',
     displayName: '筆算',
     description:
-      '筆算形式。多桁の乗算では部分積と合計を書くスペースが必要なため余白を広めに確保。',
+      '筆算形式。3桁×2桁のかけ算など部分積を書く問題に合わせて最小高さを設定。' +
+      '行間は広げすぎず alignContent:space-between で均等配分する。',
     layout: {
-      rowGap: '56px',
+      rowGap: '32px',
       colGap: '32px',
       fontSize: '18px',
-      minProblemHeight: '140px',
+      minProblemHeight: '200px',
     },
     recommendedCounts: {
       1: 4,

--- a/src/config/styles.ts
+++ b/src/config/styles.ts
@@ -261,7 +261,7 @@ export const hissanContainerStyle: CSSProperties = {
   display: 'inline-block',
   textAlign: 'right',
   lineHeight: HISSAN_STYLES.lineHeight,
-  margin: `${SPACING.margin.medium} 0`,
+  margin: `${SPACING.margin.small} 0`,
 };
 
 /**

--- a/src/config/styles.ts
+++ b/src/config/styles.ts
@@ -253,6 +253,16 @@ export const hissanAnswerBoxStyle: CSSProperties = {
 export const HISSAN_ANSWER_GAP = 4;
 
 /**
+ * 筆算の行スタイル（全行で同じ gap を使い列を揃える）
+ */
+export const hissanRowStyle: CSSProperties = {
+  display: 'flex',
+  gap: `${HISSAN_ANSWER_GAP}px`,
+  justifyContent: 'flex-end',
+  whiteSpace: 'nowrap',
+};
+
+/**
  * 筆算のコンテナスタイル
  */
 export const hissanContainerStyle: CSSProperties = {


### PR DESCRIPTION
## Summary

4年生「3桁×2桁のかけ算の筆算」で報告された2つの問題を修正：

1. **12問でも印刷すると2ページに分かれる** — 実際の問題高さ（216px）が `minProblemHeight: 140px` を大きく超えていたため、A4に収まらず溢れていた
2. **横線の幅がバラバラで短い** — 上の線は4セル分（132px）、下の線は6セル分（200px）と不揃いで、5セル幅の答え行とも一致していなかった

## 変更内容

- **`src/components/Preview/ProblemList.tsx`**: `answerWidth` を一度だけ計算し、上下の横線を答え行と同じ幅に統一
- **`src/config/print-templates.ts`**: hissan テンプレートの `rowGap` を 56px→32px、`minProblemHeight` を 140px→200px に調整（3桁×2桁の実寸に合わせる）
- **`src/config/styles.ts`**: `hissanContainerStyle` の縦マージンを 10px→4px に縮小

## 検証

- 3桁×2桁 12問がA4 1枚 (1123px = A4ぴったり) に収まることを Playwright で確認
- 3桁＋3桁の加算も従来通りレンダリングされることを確認
- 上下の横線・部分積行・答え行がすべて 166px で揃ったことを確認（Before: 132 / 200 / 166 バラバラ）

## Test plan

- [x] \`npm run lint\` 成功
- [x] \`npm run typecheck\` 成功
- [x] \`npm test -- --run\` 成功 (574/574)
- [x] \`npm run build\` 成功
- [x] Playwright MCPで3桁×2桁のレイアウト確認
- [x] 3桁＋3桁加算のレイアウト回帰確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)