### PR TITLE
fix(fraction): 分数パターンがbasicテンプレにフォールバックしてA4から溢れる問題を修正

### DIFF
--- a/src/config/print-templates.ts
+++ b/src/config/print-templates.ts
@@ -186,28 +186,30 @@ export const PRINT_TEMPLATES = {
   mixed: createPrintTemplate({
     type: 'mixed',
     displayName: '帯分数',
-    description: '帯分数の計算。MathML表示のため広めの間隔。',
+    description:
+      '帯分数の計算。帯分数 + 分数の縦組みMathML表示のため1問あたりの高さが大きく、' +
+      '7行（1列7問/2列14問/3列21問）でA4に収まる想定。',
     layout: {
       rowGap: '24px',
       colGap: '32px',
       fontSize: '18px',
-      minProblemHeight: '55px',
+      minProblemHeight: '100px',
     },
     recommendedCounts: {
-      1: 8,
-      2: 16,
-      3: 24,
+      1: 7,
+      2: 14,
+      3: 21,
     },
     maxCounts: {
-      1: 10,
-      2: 18,
-      3: 27,
+      1: 7,
+      2: 14,
+      3: 21,
     },
     fitsInA4: {
       threshold: {
-        1: 8,
-        2: 16,
-        3: 24,
+        1: 7,
+        2: 14,
+        3: 21,
       },
     },
   }),

--- a/src/config/print-templates.ts
+++ b/src/config/print-templates.ts
@@ -124,28 +124,30 @@ export const PRINT_TEMPLATES = {
   fraction: createPrintTemplate({
     type: 'fraction',
     displayName: '分数',
-    description: '分数の計算。MathML表示のため標準より少し広め。',
+    description:
+      '分数の計算。分子・分母を縦に表示するため1問あたりの高さが大きく、' +
+      '7行（1列7問/2列14問/3列21問）でA4に収まる想定。',
     layout: {
       rowGap: '24px',
       colGap: '32px',
       fontSize: '18px',
-      minProblemHeight: '50px',
+      minProblemHeight: '100px',
     },
     recommendedCounts: {
-      1: 10,
-      2: 18,
-      3: 27,
+      1: 7,
+      2: 14,
+      3: 21,
     },
     maxCounts: {
-      1: 10,
-      2: 18,
-      3: 27,
+      1: 7,
+      2: 14,
+      3: 21,
     },
     fitsInA4: {
       threshold: {
-        1: 10,
-        2: 18,
-        3: 27,
+        1: 7,
+        2: 14,
+        3: 21,
       },
     },
   }),

--- a/src/config/problem-patterns.ts
+++ b/src/config/problem-patterns.ts
@@ -132,6 +132,24 @@ export const HISSAN_PATTERNS: readonly CalculationPattern[] = [
   'hissan-div-basic', // わり算の筆算
 ] as const;
 
+/**
+ * 分数を生成する計算パターン（帯分数は MIXED_NUMBER_PATTERNS）
+ */
+export const FRACTION_PATTERNS: readonly CalculationPattern[] = [
+  'frac-same-denom', // 同分母分数の加減
+  'frac-different-denom', // 異分母分数の加減算
+  'frac-simplify', // 分数の約分
+  'frac-mult', // 分数×分数
+  'frac-div', // 分数÷分数
+] as const;
+
+/**
+ * 帯分数を生成する計算パターン
+ */
+export const MIXED_NUMBER_PATTERNS: readonly CalculationPattern[] = [
+  'frac-mixed-number', // 帯分数の計算
+] as const;
+
 export const ANZAN_PATTERNS: readonly CalculationPattern[] = [
   'anzan-complement-10',
   'anzan-complement-100',
@@ -196,4 +214,18 @@ export function isSingaporeDiagramPattern(
  */
 export function isAnzanPattern(pattern?: CalculationPattern): boolean {
   return pattern !== undefined && ANZAN_PATTERNS.includes(pattern);
+}
+
+/**
+ * パターンが分数問題かどうかを判定
+ */
+export function isFractionPattern(pattern?: CalculationPattern): boolean {
+  return pattern !== undefined && FRACTION_PATTERNS.includes(pattern);
+}
+
+/**
+ * パターンが帯分数問題かどうかを判定
+ */
+export function isMixedNumberPattern(pattern?: CalculationPattern): boolean {
+  return pattern !== undefined && MIXED_NUMBER_PATTERNS.includes(pattern);
 }

--- a/src/lib/utils/problem-type-detector.test.ts
+++ b/src/lib/utils/problem-type-detector.test.ts
@@ -58,3 +58,23 @@ describe('problem-type-detector anzan classification', () => {
     expect(getEffectiveProblemType('fraction', undefined)).toBe('fraction');
   });
 });
+
+describe('problem-type-detector explicit problem type priority', () => {
+  it('keeps explicit decimal type even if stale fraction pattern remains', () => {
+    expect(getEffectiveProblemType('decimal', 'frac-mult')).toBe('decimal');
+  });
+
+  it('keeps explicit basic-derived type when not in basic mode', () => {
+    expect(getEffectiveProblemType('hissan', 'frac-div')).toBe('hissan');
+    expect(getEffectiveProblemType('missing', 'frac-simplify')).toBe('missing');
+  });
+
+  it('still routes fraction and mixed templates in basic mode', () => {
+    expect(getEffectiveProblemType('basic', 'frac-same-denom')).toBe(
+      'fraction'
+    );
+    expect(getEffectiveProblemType('basic', 'frac-mixed-number')).toBe(
+      'mixed'
+    );
+  });
+});

--- a/src/lib/utils/problem-type-detector.ts
+++ b/src/lib/utils/problem-type-detector.ts
@@ -5,6 +5,8 @@ import {
   isAnzanPattern,
   isSingaporePattern,
   isSingaporeDiagramPattern,
+  isFractionPattern,
+  isMixedNumberPattern,
 } from '../../config/problem-patterns';
 
 /**
@@ -90,6 +92,12 @@ export function getEffectiveProblemType(
   }
   if (isAnzanPattern(calculationPattern)) {
     return 'anzan';
+  }
+  if (isMixedNumberPattern(calculationPattern)) {
+    return 'mixed';
+  }
+  if (isFractionPattern(calculationPattern)) {
+    return 'fraction';
   }
   return problemType || 'basic';
 }

--- a/src/lib/utils/problem-type-detector.ts
+++ b/src/lib/utils/problem-type-detector.ts
@@ -93,10 +93,10 @@ export function getEffectiveProblemType(
   if (isAnzanPattern(calculationPattern)) {
     return 'anzan';
   }
-  if (isMixedNumberPattern(calculationPattern)) {
+  if (problemType === 'basic' && isMixedNumberPattern(calculationPattern)) {
     return 'mixed';
   }
-  if (isFractionPattern(calculationPattern)) {
+  if (problemType === 'basic' && isFractionPattern(calculationPattern)) {
     return 'fraction';
   }
   return problemType || 'basic';


### PR DESCRIPTION
## Summary

\`fix/hissan-mult-advanced-layout\` (#58) で3桁×2桁のかけ算を修正した流れで、全問題パターンを Playwright で俯瞰監査したところ、**5つの分数パターンが A4 から 312px も溢れる**ことが判明。原因は \`getEffectiveProblemType\` が分数パターンを検知できず \`basic\` テンプレート（30問上限）にフォールバックしていたこと。

## 影響を受けていたパターン

| Grade | Pattern | Before | After |
| ----- | ------- | ------ | ----- |
| 3 | frac-same-denom | 20問/2列, h=1435px ❌ | 14問/2列, h=1123px ✅ |
| 5 | frac-different-denom | 20問/2列, h=1435px ❌ | 14問/2列, h=1123px ✅ |
| 5 | frac-simplify | 20問/2列, h=1435px ❌ | 14問/2列, h=1123px ✅ |
| 6 | frac-mult | 20問/2列, h=1435px ❌ | 14問/2列, h=1123px ✅ |
| 6 | frac-div | 20問/2列, h=1435px ❌ | 14問/2列, h=1123px ✅ |

*frac-mixed-number (4年) は \`type: 'mixed'\` を生成していたため元々 basic 用に小さく描画されており溢れなかったが、同じパスで \`mixed\` テンプレに正しくルーティングされるよう修正。*

## 変更内容

- **\`src/config/problem-patterns.ts\`**: \`FRACTION_PATTERNS\` と \`MIXED_NUMBER_PATTERNS\` 配列、および \`isFractionPattern\` / \`isMixedNumberPattern\` 関数を追加
- **\`src/lib/utils/problem-type-detector.ts\`**: \`getEffectiveProblemType\` が分数パターンを \`'fraction'\`、帯分数を \`'mixed'\` にルーティングするよう修正
- **\`src/config/print-templates.ts\`**: fraction テンプレの実寸を正確に反映（\`minProblemHeight\` 50→100px、\`recommendedCounts\` 10/18/27 → 7/14/21）

## Test plan

- [x] \`npm run lint\` 成功
- [x] \`npm run typecheck\` 成功
- [x] \`npm test -- --run\` 成功 (574/574)
- [x] \`npm run build\` 成功
- [x] Playwright で全6分数パターンが A4 に収まることを確認
- [x] 小数・筆算・暗算など他パターンが影響を受けていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)