### PR TITLE
feat(tracing): 0〜4/5〜9の左右2分割レイアウトと教科書体準拠の数字に刷新

### DIFF
--- a/src/components/Math/NumberTracingRow.tsx
+++ b/src/components/Math/NumberTracingRow.tsx
@@ -237,9 +237,9 @@ export const NumberTracingRow: React.FC<NumberTracingRowProps> = ({
       {/* 数字ラベル */}
       <div
         style={{
-          fontSize: 18,
+          fontSize: 24,
           fontWeight: 'bold',
-          minWidth: 24,
+          minWidth: 28,
           textAlign: 'center',
           color: '#0f172a',
         }}

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -199,30 +199,33 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
             </div>
           </div>
 
-          <div data-problem-grid className={gridCols} style={gridGapStyle}>
-            {reorderedProblems.map((problem, index) => {
-              if (!problem) {
-                // 空のセルを配置（レイアウトを保つため）
-                return <div key={`empty-${index}`} className="avoid-break" />;
-              }
+          {effectiveProblemType === 'number-tracing' ? (
+            <NumberTracingGrid problems={problems} />
+          ) : (
+            <div data-problem-grid className={gridCols} style={gridGapStyle}>
+              {reorderedProblems.map((problem, index) => {
+                if (!problem) {
+                  // 空のセルを配置（レイアウトを保つため）
+                  return <div key={`empty-${index}`} className="avoid-break" />;
+                }
 
-              // 元のインデックスを計算（縦順から横順へ）
-              const col = index % layoutColumns;
-              const row = Math.floor(index / layoutColumns);
-              const originalNumber = col * rowCount + row + 1;
+                // 元のインデックスを計算（縦順から横順へ）
+                const col = index % layoutColumns;
+                const row = Math.floor(index / layoutColumns);
+                const originalNumber = col * rowCount + row + 1;
 
-              return (
-                <div key={problem.id} className="avoid-break">
-                  <ProblemItem
-                    problem={problem}
-                    number={originalNumber}
-                    showAnswer={showAnswers}
-                    layoutColumns={layoutColumns}
-                  />
-                </div>
-              );
-            })}
-          </div>
+                return (
+                  <div key={problem.id} className="avoid-break">
+                    <ProblemItem
+                      problem={problem}
+                      number={originalNumber}
+                      showAnswer={showAnswers}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       </>
     );
@@ -241,6 +244,77 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
 );
 
 ProblemList.displayName = 'ProblemList';
+
+/**
+ * 数字なぞり書き専用のレイアウト
+ * 0〜4 を左、5〜9 を右に配置し、各セルを大きく表示する
+ */
+const NumberTracingGrid: React.FC<{ problems: Problem[] }> = ({ problems }) => {
+  // digit ごとに 1 つだけ採用（重複や count > 10 を防ぐ）
+  const byDigit = new Map<number, NumberTracingProblem>();
+  for (const p of problems) {
+    if (p.type !== 'number-tracing') continue;
+    const tp = p as NumberTracingProblem;
+    if (!byDigit.has(tp.digit)) {
+      byDigit.set(tp.digit, tp);
+    }
+  }
+  const left: NumberTracingProblem[] = [];
+  const right: NumberTracingProblem[] = [];
+  for (let d = 0; d <= 4; d++) {
+    const p = byDigit.get(d);
+    if (p) left.push(p);
+  }
+  for (let d = 5; d <= 9; d++) {
+    const p = byDigit.get(d);
+    if (p) right.push(p);
+  }
+
+  // A4 縦印刷で 5 行 × 2 側 に収まる大きめのセル
+  const cellHeight = 70;
+  const traceCount = 2;
+  const practiceCount = 2;
+
+  const renderColumn = (items: NumberTracingProblem[]): React.ReactElement => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 12,
+        flex: 1,
+        minWidth: 0,
+      }}
+    >
+      {items.map((p) => (
+        <div key={p.id} className="avoid-break">
+          <NumberTracingRow
+            digit={p.digit}
+            traceCount={Math.min(p.traceCount, traceCount)}
+            practiceCount={Math.min(p.practiceCount, practiceCount)}
+            cellHeight={cellHeight}
+          />
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div
+      data-problem-grid
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        columnGap: 24,
+        flex: 1,
+        alignItems: 'stretch',
+        justifyContent: 'space-between',
+      }}
+    >
+      {renderColumn(left)}
+      {renderColumn(right)}
+    </div>
+  );
+};
 
 /** 筆算の答え行（記入欄または解答表示） */
 const HissanAnswerRow: React.FC<{
@@ -324,14 +398,12 @@ interface ProblemItemProps {
   problem: Problem;
   number: number;
   showAnswer?: boolean;
-  layoutColumns?: LayoutColumns;
 }
 
 function ProblemItem({
   problem,
   number,
   showAnswer = false,
-  layoutColumns = 1,
 }: ProblemItemProps): React.ReactElement {
   const operationSymbol = {
     addition: '+',
@@ -339,25 +411,6 @@ function ProblemItem({
     multiplication: '×',
     division: '÷',
   }[problem.operation];
-
-  // 数字なぞり書きの場合
-  if (problem.type === 'number-tracing') {
-    const tracingProblem = problem as NumberTracingProblem;
-    // 列数に応じてセルサイズと練習マス数を調整
-    const cellHeight = layoutColumns === 1 ? 56 : layoutColumns === 2 ? 44 : 36;
-    const traceCount = layoutColumns === 1 ? 3 : layoutColumns === 2 ? 2 : 1;
-    const practiceCount = layoutColumns === 1 ? 3 : layoutColumns === 2 ? 2 : 1;
-    return (
-      <div style={problemItemStyle}>
-        <NumberTracingRow
-          digit={tracingProblem.digit}
-          traceCount={Math.min(tracingProblem.traceCount, traceCount)}
-          practiceCount={Math.min(tracingProblem.practiceCount, practiceCount)}
-          cellHeight={cellHeight}
-        />
-      </div>
-    );
-  }
 
   // 分数問題の場合
   if (problem.type === 'fraction') {

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -271,9 +271,12 @@ const NumberTracingGrid: React.FC<{ problems: Problem[] }> = ({ problems }) => {
   }
 
   // A4 縦印刷で 5 行 × 2 側 に収まる大きめのセル
+  // 1セル幅は cellHeight × (100/140) + border + padding ≈ cellHeight*0.714 + 6
+  // 1列の利用可能幅 ≈ (210mm − 30mm side padding − 24px gap) / 2 ≈ 328px
+  // 1行 = ラベル(28) + 4セル + 4ギャップ(8) ≈ 28 + 4*(70*0.714+6) + 32 ≈ 284px ✓
   const cellHeight = 70;
   const traceCount = 2;
-  const practiceCount = 2;
+  const practiceCount = 1;
 
   const renderColumn = (items: NumberTracingProblem[]): React.ReactElement => (
     <div

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -24,6 +24,11 @@ import { SingaporeProblemComponent } from '../Math/SingaporeProblemComponent';
 import { NumberTracingRow } from '../Math/NumberTracingRow';
 import type { NumberTracingProblem } from '../../types';
 import { getPrintTemplate } from '../../config/print-templates';
+import {
+  NUMBER_TRACING_CELL_HEIGHT_PX,
+  NUMBER_TRACING_COL_GAP_PX,
+  NUMBER_TRACING_ROW_GAP_PX,
+} from '../../config/number-tracing-layout';
 import { getEffectiveProblemType } from '../../lib/utils/problem-type-detector';
 import { estimateA4Fit } from '../../lib/utils/print-validator';
 import { buildPreviewTitle } from '../../lib/utils/previewTitle';
@@ -270,11 +275,8 @@ const NumberTracingGrid: React.FC<{ problems: Problem[] }> = ({ problems }) => {
     if (p) right.push(p);
   }
 
-  // A4 縦印刷で 5 行 × 2 側 に収まる大きめのセル
-  // 1セル幅は cellHeight × (100/140) + border + padding ≈ cellHeight*0.714 + 6
-  // 1列の利用可能幅 ≈ (210mm − 30mm side padding − 24px gap) / 2 ≈ 328px
-  // 1行 = ラベル(28) + 4セル + 4ギャップ(8) ≈ 28 + 4*(70*0.714+6) + 32 ≈ 284px ✓
-  const cellHeight = 70;
+  // レイアウト定数はテンプレート定義と共有し、A4判定との乖離を防ぐ
+  const cellHeight = NUMBER_TRACING_CELL_HEIGHT_PX;
   const traceCount = 2;
   const practiceCount = 1;
 
@@ -283,7 +285,7 @@ const NumberTracingGrid: React.FC<{ problems: Problem[] }> = ({ problems }) => {
       style={{
         display: 'flex',
         flexDirection: 'column',
-        rowGap: 12,
+        rowGap: NUMBER_TRACING_ROW_GAP_PX,
         flex: 1,
         minWidth: 0,
       }}
@@ -307,7 +309,7 @@ const NumberTracingGrid: React.FC<{ problems: Problem[] }> = ({ problems }) => {
       style={{
         display: 'flex',
         flexDirection: 'row',
-        columnGap: 24,
+        columnGap: NUMBER_TRACING_COL_GAP_PX,
         flex: 1,
         alignItems: 'stretch',
         justifyContent: 'space-between',

--- a/src/components/Preview/WorksheetPreview.tsx
+++ b/src/components/Preview/WorksheetPreview.tsx
@@ -87,7 +87,9 @@ export const WorksheetPreview: React.FC<WorksheetPreviewProps> = ({
               問題プレビュー - {buildPreviewTitle({ settings })}
             </h2>
             <div className="text-sm text-slate-500">
-              {problems.length}問 • {settings.layoutColumns}列レイアウト
+              {settings.problemType === 'number-tracing'
+                ? `${problems.length}問 • 0〜4 / 5〜9 の左右レイアウト`
+                : `${problems.length}問 • ${settings.layoutColumns}列レイアウト`}
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">

--- a/src/components/ProblemGenerator/SettingsPanel.tsx
+++ b/src/components/ProblemGenerator/SettingsPanel.tsx
@@ -42,6 +42,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   );
   const template = getPrintTemplate(effectiveProblemType);
   const isAnzan = effectiveProblemType === 'anzan';
+  const isNumberTracing = effectiveProblemType === 'number-tracing';
 
   // 列数に応じた最大問題数と推奨問題数を取得（パターン固有オーバーライド対応）
   const patternOverride = calculationPattern
@@ -106,6 +107,22 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     lessCount >= minProblems && problemCountOptions.includes(lessCount);
   const showMoreOption =
     moreCount <= maxProblems && problemCountOptions.includes(moreCount);
+
+  // なぞり書きはレイアウト・問題数固定（10問・2分割）なので設定UIを省略
+  if (isNumberTracing) {
+    return (
+      <div className="space-y-6">
+        <div className="rounded-2xl border border-sky-100 bg-sky-50/80 p-4">
+          <h4 className="mb-2 text-sm font-semibold text-sky-900">
+            レイアウトと問題数
+          </h4>
+          <p className="text-sm text-slate-600 leading-relaxed">
+            数字なぞり書きはA4一枚に0〜4を左、5〜9を右に配置した固定レイアウトです（10問）。
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/config/number-tracing-layout.ts
+++ b/src/config/number-tracing-layout.ts
@@ -1,0 +1,19 @@
+/**
+ * 数字なぞり書きレイアウトの共通定数。
+ * プレビュー描画とテンプレート推定で同じ値を使い、乖離を防ぐ。
+ */
+
+/** 左右2カラム時にA4幅へ収めるためのセル高さ */
+export const NUMBER_TRACING_CELL_HEIGHT_PX = 70;
+
+/** 行間 */
+export const NUMBER_TRACING_ROW_GAP_PX = 12;
+
+/** 列間（左右カラム間） */
+export const NUMBER_TRACING_COL_GAP_PX = 24;
+
+/**
+ * 行の見かけ高さ。
+ * cellHeight + border/padding(6px) + ラベル(9px) + ラベル間隔(2px) ≈ 90px
+ */
+export const NUMBER_TRACING_MIN_PROBLEM_HEIGHT_PX = 90;

--- a/src/config/print-templates.ts
+++ b/src/config/print-templates.ts
@@ -2,6 +2,11 @@ import {
   estimatePageLayout,
   A4_HEIGHT_MM,
 } from '../components/Export/fitPageToA4';
+import {
+  NUMBER_TRACING_COL_GAP_PX,
+  NUMBER_TRACING_MIN_PROBLEM_HEIGHT_PX,
+  NUMBER_TRACING_ROW_GAP_PX,
+} from './number-tracing-layout';
 import type { ProblemType, LayoutColumns } from '../types';
 import type { CalculationPattern } from '../types/calculation-patterns';
 
@@ -429,19 +434,18 @@ export const PRINT_TEMPLATES = {
   }),
 
   // 数字なぞり書き（幼児向け）
-  // 実際のレイアウトは左右 2 分割固定（0〜4 を左、5〜9 を右）で 1 ページ 5 行。
-  // 1 行あたりの高さは「セル(70px) + ラベル(9px) + 内部 gap(2px) + ボーダー/パディング(4+2)」≈ 90px。
-  // validator・SettingsPanel ともに「1 列あたり 5 問」として扱う（実際の縦の行数と一致）。
+  // レイアウトは左右 2 分割固定（0〜4 を左、5〜9 を右）で、実際は 5 行のみ。
+  // プレビューと同一の定数を共有し、A4判定ロジックとの乖離を抑える。
   'number-tracing': createPrintTemplate({
     type: 'number-tracing',
     displayName: '数字なぞり書き',
     description:
       '幼児向けの数字書き方練習。0〜4を左、5〜9を右に配置し、書き順付きお手本・なぞり書き・自由練習マスを表示。',
     layout: {
-      rowGap: '12px',
-      colGap: '24px',
+      rowGap: `${NUMBER_TRACING_ROW_GAP_PX}px`,
+      colGap: `${NUMBER_TRACING_COL_GAP_PX}px`,
       fontSize: '14px',
-      minProblemHeight: '90px',
+      minProblemHeight: `${NUMBER_TRACING_MIN_PROBLEM_HEIGHT_PX}px`,
     },
     recommendedCounts: {
       1: 5,

--- a/src/config/print-templates.ts
+++ b/src/config/print-templates.ts
@@ -429,34 +429,35 @@ export const PRINT_TEMPLATES = {
   }),
 
   // 数字なぞり書き（幼児向け）
-  // レイアウトは左右 2 分割固定（0〜4 を左、5〜9 を右）で、実際は 5 行のみ。
-  // ただし validator は 1/2/3 列汎用で計算するため、minProblemHeight は控えめに。
+  // 実際のレイアウトは左右 2 分割固定（0〜4 を左、5〜9 を右）で 1 ページ 5 行。
+  // 1 行あたりの高さは「セル(70px) + ラベル(9px) + 内部 gap(2px) + ボーダー/パディング(4+2)」≈ 90px。
+  // validator・SettingsPanel ともに「1 列あたり 5 問」として扱う（実際の縦の行数と一致）。
   'number-tracing': createPrintTemplate({
     type: 'number-tracing',
     displayName: '数字なぞり書き',
     description:
       '幼児向けの数字書き方練習。0〜4を左、5〜9を右に配置し、書き順付きお手本・なぞり書き・自由練習マスを表示。',
     layout: {
-      rowGap: '4px',
+      rowGap: '12px',
       colGap: '24px',
       fontSize: '14px',
-      minProblemHeight: '70px',
+      minProblemHeight: '90px',
     },
     recommendedCounts: {
-      1: 10,
-      2: 10,
-      3: 10,
+      1: 5,
+      2: 5,
+      3: 5,
     },
     maxCounts: {
-      1: 10,
-      2: 10,
-      3: 10,
+      1: 5,
+      2: 5,
+      3: 5,
     },
     fitsInA4: {
       threshold: {
-        1: 10,
-        2: 10,
-        3: 10,
+        1: 5,
+        2: 5,
+        3: 5,
       },
     },
   }),

--- a/src/config/print-templates.ts
+++ b/src/config/print-templates.ts
@@ -429,32 +429,34 @@ export const PRINT_TEMPLATES = {
   }),
 
   // 数字なぞり書き（幼児向け）
+  // レイアウトは左右 2 分割固定（0〜4 を左、5〜9 を右）で、実際は 5 行のみ。
+  // ただし validator は 1/2/3 列汎用で計算するため、minProblemHeight は控えめに。
   'number-tracing': createPrintTemplate({
     type: 'number-tracing',
     displayName: '数字なぞり書き',
     description:
-      '幼児向けの数字書き方練習。書き順付きのお手本、なぞり書き、自由練習マスを横並びで表示。',
+      '幼児向けの数字書き方練習。0〜4を左、5〜9を右に配置し、書き順付きお手本・なぞり書き・自由練習マスを表示。',
     layout: {
       rowGap: '4px',
-      colGap: '16px',
+      colGap: '24px',
       fontSize: '14px',
-      minProblemHeight: '55px',
+      minProblemHeight: '70px',
     },
     recommendedCounts: {
       1: 10,
-      2: 20,
-      3: 30,
+      2: 10,
+      3: 10,
     },
     maxCounts: {
       1: 10,
-      2: 20,
-      3: 30,
+      2: 10,
+      3: 10,
     },
     fitsInA4: {
       threshold: {
         1: 10,
-        2: 20,
-        3: 30,
+        2: 10,
+        3: 10,
       },
     },
   }),

--- a/src/lib/data/digit-strokes.ts
+++ b/src/lib/data/digit-strokes.ts
@@ -1,6 +1,6 @@
 /**
  * 数字0〜9のSVGストロークデータ（書き順付き）
- * 日本の書き順に準拠
+ * 日本の小学校教科書体（学参フォント系）に準拠した字形
  * viewBox: 0 0 100 140 で統一
  */
 
@@ -26,17 +26,23 @@ export const DIGIT_VIEWBOX = { width: 100, height: 140 };
 /**
  * 数字0〜9のストロークデータ
  * パスは viewBox 0 0 100 140 内で定義
+ *
+ * 字形ルール:
+ *   - 上端 y=18, 下端 y=125 を基本ベースライン
+ *   - 横幅は概ね x=18..82 に収める
+ *   - 0,1,2,3,6,8 = 1画 / 5,7,9 = 2画 / 4 = 3画
+ *   - 角張った形（4,7）は鋭角を保つ。丸い形（0,3,6,8,9）は対称性重視
  */
 export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
   0: {
     digit: 0,
     strokes: [
       {
-        // 楕円：上部中央から時計回り
-        path: 'M 50 20 C 75 20, 85 50, 85 70 C 85 100, 70 125, 50 125 C 30 125, 15 100, 15 70 C 15 50, 25 20, 50 20 Z',
+        // 左右対称な楕円。上中央から反時計回り → 戻りで閉じる
+        path: 'M 50 18 C 28 18, 17 45, 17 71 C 17 98, 28 124, 50 124 C 72 124, 83 98, 83 71 C 83 45, 72 18, 50 18 Z',
         order: 1,
-        arrowStart: { x: 50, y: 20 },
-        arrowDirection: { x: 65, y: 22 },
+        arrowStart: { x: 50, y: 18 },
+        arrowDirection: { x: 35, y: 22 },
       },
     ],
   },
@@ -44,11 +50,11 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 1,
     strokes: [
       {
-        // 上から下へ直線
-        path: 'M 50 15 L 50 125',
+        // 教科書体の1：左上に短いフラッグ → 中心へ縦線。底部にわずかな横線
+        path: 'M 28 35 L 50 18 L 50 124 M 32 124 L 68 124',
         order: 1,
-        arrowStart: { x: 50, y: 15 },
-        arrowDirection: { x: 50, y: 35 },
+        arrowStart: { x: 28, y: 35 },
+        arrowDirection: { x: 42, y: 24 },
       },
     ],
   },
@@ -56,11 +62,11 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 2,
     strokes: [
       {
-        // 左上から弧を描いて右下、そして横線
-        path: 'M 25 40 C 25 20, 75 15, 75 45 C 75 65, 25 95, 20 120 L 80 120',
+        // 上の弧を滑らかに、底辺はきっぱり水平
+        path: 'M 22 38 C 22 22, 38 16, 52 16 C 70 16, 80 26, 80 42 C 80 58, 60 78, 22 122 L 82 122',
         order: 1,
-        arrowStart: { x: 25, y: 40 },
-        arrowDirection: { x: 30, y: 28 },
+        arrowStart: { x: 22, y: 38 },
+        arrowDirection: { x: 26, y: 26 },
       },
     ],
   },
@@ -68,11 +74,11 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 3,
     strokes: [
       {
-        // 一筆書き：上の弧 → 中央 → 下の弧
-        path: 'M 25 30 C 25 12, 80 12, 75 40 C 72 55, 55 62, 50 65 C 60 65, 82 75, 80 95 C 78 118, 25 125, 22 105',
+        // 上下の弧。中央でしっかりくびれを作って2つの輪の境界を明確に
+        path: 'M 22 30 C 22 14, 42 14, 56 18 C 76 24, 78 48, 56 60 C 50 63, 42 64, 38 64 C 44 64, 56 64, 66 70 C 84 80, 82 110, 60 120 C 40 128, 24 122, 20 108',
         order: 1,
-        arrowStart: { x: 25, y: 30 },
-        arrowDirection: { x: 35, y: 18 },
+        arrowStart: { x: 22, y: 30 },
+        arrowDirection: { x: 32, y: 18 },
       },
     ],
   },
@@ -80,25 +86,25 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 4,
     strokes: [
       {
-        // 左上から斜め下へ
-        path: 'M 65 15 L 15 90',
+        // 1画目: 左上から斜め下へ（左下がり）
+        path: 'M 60 18 L 16 88',
         order: 1,
-        arrowStart: { x: 65, y: 15 },
-        arrowDirection: { x: 55, y: 35 },
+        arrowStart: { x: 60, y: 18 },
+        arrowDirection: { x: 50, y: 33 },
       },
       {
-        // 横線
-        path: 'M 15 90 L 85 90',
+        // 2画目: 横線（左から右）
+        path: 'M 16 88 L 84 88',
         order: 2,
-        arrowStart: { x: 15, y: 90 },
-        arrowDirection: { x: 35, y: 90 },
+        arrowStart: { x: 16, y: 88 },
+        arrowDirection: { x: 36, y: 88 },
       },
       {
-        // 縦線
-        path: 'M 65 50 L 65 125',
+        // 3画目: 縦線（上から下）
+        path: 'M 64 40 L 64 124',
         order: 3,
-        arrowStart: { x: 65, y: 50 },
-        arrowDirection: { x: 65, y: 70 },
+        arrowStart: { x: 64, y: 40 },
+        arrowDirection: { x: 64, y: 60 },
       },
     ],
   },
@@ -106,18 +112,18 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 5,
     strokes: [
       {
-        // 縦→カーブ（先に書く）
-        path: 'M 30 20 L 28 65 C 28 55, 80 50, 82 85 C 84 115, 30 130, 20 108',
+        // 1画目: 縦線 → 右下へ膨らむ大きなカーブ → 左下へ収束
+        path: 'M 28 22 L 28 62 C 38 56, 60 54, 72 64 C 86 76, 84 110, 64 120 C 44 128, 24 120, 18 106',
         order: 1,
-        arrowStart: { x: 30, y: 20 },
-        arrowDirection: { x: 29, y: 40 },
+        arrowStart: { x: 28, y: 22 },
+        arrowDirection: { x: 28, y: 42 },
       },
       {
-        // 上の横線（最後に書く：左から右）
-        path: 'M 30 20 L 75 20',
+        // 2画目: 上の横線（左から右）
+        path: 'M 28 22 L 72 22',
         order: 2,
-        arrowStart: { x: 30, y: 20 },
-        arrowDirection: { x: 50, y: 20 },
+        arrowStart: { x: 28, y: 22 },
+        arrowDirection: { x: 50, y: 22 },
       },
     ],
   },
@@ -125,11 +131,11 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 6,
     strokes: [
       {
-        // 上から丸く下へ
-        path: 'M 65 20 C 40 20, 18 55, 18 80 C 18 110, 35 125, 55 125 C 75 125, 85 110, 85 90 C 85 70, 70 60, 50 60 C 30 60, 18 72, 18 80',
+        // 滑らかな弧 → 下のループ。1画で閉じる
+        path: 'M 70 22 C 50 18, 30 36, 22 60 C 16 78, 16 100, 28 116 C 42 128, 66 128, 78 114 C 88 100, 86 80, 72 72 C 58 64, 38 68, 28 80 C 22 88, 20 98, 22 108',
         order: 1,
-        arrowStart: { x: 65, y: 20 },
-        arrowDirection: { x: 52, y: 22 },
+        arrowStart: { x: 70, y: 22 },
+        arrowDirection: { x: 56, y: 21 },
       },
     ],
   },
@@ -137,18 +143,18 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 7,
     strokes: [
       {
-        // 横線
-        path: 'M 20 20 L 80 20',
+        // 1画目: 鋭く水平な横線（教科書体の7は水平を強調）
+        path: 'M 18 24 L 82 24',
         order: 1,
-        arrowStart: { x: 20, y: 20 },
-        arrowDirection: { x: 40, y: 20 },
+        arrowStart: { x: 18, y: 24 },
+        arrowDirection: { x: 38, y: 24 },
       },
       {
-        // 斜め下へ
-        path: 'M 80 20 L 40 125',
+        // 2画目: 右端から左下へ直線。鋭角を保つため角の丸めなしの直線
+        path: 'M 78 24 L 36 124',
         order: 2,
-        arrowStart: { x: 80, y: 20 },
-        arrowDirection: { x: 72, y: 42 },
+        arrowStart: { x: 78, y: 24 },
+        arrowDirection: { x: 70, y: 44 },
       },
     ],
   },
@@ -156,11 +162,11 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 8,
     strokes: [
       {
-        // 一筆書き：上の丸 → 中央交差 → 下の丸 → 戻り
-        path: 'M 60 22 C 35 22, 22 35, 22 50 C 22 60, 35 65, 50 65 C 70 65, 85 80, 85 100 C 85 118, 68 128, 50 128 C 32 128, 15 118, 15 100 C 15 80, 30 65, 50 65 C 65 65, 78 60, 78 50 C 78 35, 65 22, 50 22',
+        // 上の輪（小さめ） → 中央交差 → 下の輪（大きめ） → 戻りで閉じる
+        path: 'M 56 22 C 38 22, 28 32, 28 46 C 28 56, 38 64, 50 66 C 64 68, 78 80, 78 100 C 78 116, 64 126, 50 126 C 36 126, 22 116, 22 100 C 22 80, 36 68, 50 66 C 62 64, 72 56, 72 46 C 72 32, 62 22, 50 22',
         order: 1,
-        arrowStart: { x: 60, y: 22 },
-        arrowDirection: { x: 48, y: 24 },
+        arrowStart: { x: 56, y: 22 },
+        arrowDirection: { x: 44, y: 24 },
       },
     ],
   },
@@ -168,18 +174,18 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 9,
     strokes: [
       {
-        // 上の丸
-        path: 'M 82 60 C 82 40, 70 18, 50 18 C 30 18, 18 35, 18 55 C 18 72, 35 82, 50 82 C 68 82, 82 72, 82 55',
+        // 1画目: 上の輪（左上から開始 → 右回り → 左下で閉じる）
+        path: 'M 78 50 C 78 32, 66 18, 50 18 C 32 18, 22 34, 22 50 C 22 66, 34 78, 50 78 C 64 78, 78 70, 78 50',
         order: 1,
-        arrowStart: { x: 82, y: 60 },
-        arrowDirection: { x: 82, y: 48 },
+        arrowStart: { x: 78, y: 50 },
+        arrowDirection: { x: 76, y: 36 },
       },
       {
-        // 下へ伸ばす
-        path: 'M 82 55 L 82 90 C 82 110, 70 128, 45 128',
+        // 2画目: 上の輪の右端から下へ伸ばし、わずかにカーブして終わる
+        path: 'M 78 50 L 78 96 C 78 116, 64 126, 42 124',
         order: 2,
-        arrowStart: { x: 82, y: 55 },
-        arrowDirection: { x: 82, y: 75 },
+        arrowStart: { x: 78, y: 50 },
+        arrowDirection: { x: 78, y: 70 },
       },
     ],
   },

--- a/src/lib/data/digit-strokes.ts
+++ b/src/lib/data/digit-strokes.ts
@@ -50,8 +50,8 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 1,
     strokes: [
       {
-        // 教科書体の1：左上に短いフラッグ → 中心へ縦線。底部にわずかな横線
-        path: 'M 28 35 L 50 18 L 50 124 M 32 124 L 68 124',
+        // 教科書体の1：左上に短いフラッグ → 中心へ縦線（1画で書く）
+        path: 'M 28 35 L 50 18 L 50 124',
         order: 1,
         arrowStart: { x: 28, y: 35 },
         arrowDirection: { x: 42, y: 24 },

--- a/src/lib/data/digit-strokes.ts
+++ b/src/lib/data/digit-strokes.ts
@@ -50,7 +50,6 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 1,
     strokes: [
       {
-        // 教科書体の1：左上に短いフラッグ → 中心へ縦線
         // 教科書体の1：左上に短いフラッグ → 中心へ縦線（1画で書く）
         path: 'M 28 35 L 50 18 L 50 124',
         order: 1,

--- a/src/lib/data/digit-strokes.ts
+++ b/src/lib/data/digit-strokes.ts
@@ -50,6 +50,7 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 1,
     strokes: [
       {
+        // 教科書体の1：左上に短いフラッグ → 中心へ縦線
         // 教科書体の1：左上に短いフラッグ → 中心へ縦線（1画で書く）
         path: 'M 28 35 L 50 18 L 50 124',
         order: 1,

--- a/src/lib/generators/index.ts
+++ b/src/lib/generators/index.ts
@@ -35,7 +35,8 @@ export function generateProblems(settings: WorksheetSettings): Problem[] {
 
   // 問題タイプ別の処理
   if (problemType === 'number-tracing') {
-    return generateNumberTracingProblems(problemCount);
+    // なぞり書きは 0〜9 の 10 問固定（左右 5 つずつのレイアウト）
+    return generateNumberTracingProblems(10);
   }
 
   if (problemType === 'fraction') {


### PR DESCRIPTION
## Summary

- 数字なぞり書きプリントを「0〜4 を左、5〜9 を右」の固定2分割レイアウトに変更し、各セルを大きく（44px→70px）してなぞり書きしやすく改善
- 全10字の SVG パスを教科書体（学参フォント系）の字形に再設計。特に数字「7」を鋭角な2画（横線→斜め線）として明確化、数字「1」に教科書体らしい上部フラッグを追加
- なぞり書き選択時はレイアウト・問題数セレクタを非表示にし、固定設定の説明を表示

## 変更点

| ファイル | 変更内容 |
| -------- | -------- |
| `src/components/Preview/ProblemList.tsx` | `NumberTracingGrid` を追加し、`number-tracing` をトップレベルで特殊扱い。旧 ProblemItem 内分岐を削除 |
| `src/lib/data/digit-strokes.ts` | 全10字の SVG パスを再設計。0,1,2,3,6,8 = 1画 / 5,7,9 = 2画 / 4 = 3画 |
| `src/components/Math/NumberTracingRow.tsx` | 数字ラベルを 18px→24px に拡大 |
| `src/lib/generators/index.ts` | なぞり書きは常に10問固定 |
| `src/config/print-templates.ts` | テンプレート設定を新レイアウト用に調整 |
| `src/components/ProblemGenerator/SettingsPanel.tsx` | なぞり書きでは列・問題数セレクタを非表示 |
| `src/components/Preview/WorksheetPreview.tsx` | ヘッダー右上の表示を「0〜4 / 5〜9 の左右レイアウト」に |

## Before / After

Before: 2列を選ぶと 0〜9 が両列に重複表示され、各セルが小さい
After: 0〜4 を左、5〜9 を右に1セットだけ表示し、各セルを約1.6倍に拡大

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- --run`（577 tests passed）
- [x] `npm run build`
- [x] Playwright MCP で `?grade=0&type=number-tracing` を視覚確認（A4 1枚に収まる、数字7が明確な2画、ラベルが大きい）

🤖 Generated with [Claude Code](https://claude.com/claude-code)