### PR TITLE
fix(tracing): 数字7の左の棒を下向きに修正

### DIFF
--- a/src/lib/data/digit-strokes.ts
+++ b/src/lib/data/digit-strokes.ts
@@ -152,10 +152,11 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
       },
       {
         // 2画目: 上の横棒から続けて斜め下へ一筆で書く（横→斜め）
+        // arrowStart はパスの実際の書き始め位置 (22, 26) と一致させる（教科書順序の正確性を優先）
         path: 'M 22 26 L 80 26 L 36 124',
         order: 2,
-        arrowStart: { x: 32, y: 26 },
-        arrowDirection: { x: 50, y: 26 },
+        arrowStart: { x: 22, y: 26 },
+        arrowDirection: { x: 42, y: 26 },
       },
     ],
   },

--- a/src/lib/data/digit-strokes.ts
+++ b/src/lib/data/digit-strokes.ts
@@ -143,18 +143,19 @@ export const DIGIT_STROKES: Record<number, DigitStrokeData> = {
     digit: 7,
     strokes: [
       {
-        // 1画目: 左上の短い縦の棒（教科書体の serif として上から下へ）
-        path: 'M 22 14 L 22 26',
+        // 1画目: 上の横棒の左端から下へ伸びる短い縦の棒（教科書体 serif）
+        // 横棒(y=26)の起点から長さ約30で下へ。幼児でも書きやすいサイズ
+        path: 'M 22 26 L 22 56',
         order: 1,
-        arrowStart: { x: 22, y: 14 },
-        arrowDirection: { x: 22, y: 22 },
+        arrowStart: { x: 22, y: 30 },
+        arrowDirection: { x: 22, y: 44 },
       },
       {
         // 2画目: 上の横棒から続けて斜め下へ一筆で書く（横→斜め）
         path: 'M 22 26 L 80 26 L 36 124',
         order: 2,
-        arrowStart: { x: 22, y: 26 },
-        arrowDirection: { x: 42, y: 26 },
+        arrowStart: { x: 32, y: 26 },
+        arrowDirection: { x: 50, y: 26 },
       },
     ],
   },


### PR DESCRIPTION
## Summary

教科書体の数字7では、左の短い縦棒は上の横棒から **下へ** 伸ばすのが正しい形（serif）。これまでは横棒の **上** に飛び出していたため修正。

## Before / After

| | path | 説明 |
|---|---|---|
| Before | `M 22 14 L 22 26` | 横棒(y=26)の **上** に短い棒が飛び出していた |
| After | `M 22 26 L 22 56` | 横棒の左端から **下** へ伸びる長さ30の縦棒 |

書き順:
1. 上の横棒の左端から下へ伸ばす短い縦棒
2. 上の横棒から続けて斜め下へ一筆で書く（横→斜め）

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- --run`（577 tests passed）
- [x] Playwright MCP で視覚確認（`.playwright-cli/tracing-7-v2.png`）— 左の棒が下向きに、横棒の上に飛び出していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)