### PR TITLE
fix(tracing): ラベルなしのセルでもボックス位置を揃える

### DIFF
--- a/src/components/Math/NumberTracingRow.tsx
+++ b/src/components/Math/NumberTracingRow.tsx
@@ -206,7 +206,7 @@ const Cell: React.FC<{
           visibility: label ? 'visible' : 'hidden',
         }}
       >
-        {label ?? ' '}
+        {label || '\u00a0'}
       </div>
       <div
         style={{

--- a/src/components/Math/NumberTracingRow.tsx
+++ b/src/components/Math/NumberTracingRow.tsx
@@ -197,11 +197,17 @@ const Cell: React.FC<{
         gap: 2,
       }}
     >
-      {label && (
-        <div style={{ fontSize: 9, color: '#6b7280', lineHeight: 1 }}>
-          {label}
-        </div>
-      )}
+      {/* ラベルなしの場合も同じ高さを確保してボックス位置を揃える */}
+      <div
+        style={{
+          fontSize: 9,
+          color: '#6b7280',
+          lineHeight: 1,
+          visibility: label ? 'visible' : 'hidden',
+        }}
+      >
+        {label ?? ' '}
+      </div>
       <div
         style={{
           width: size * aspect,


### PR DESCRIPTION
## Summary

数字なぞり書きプリントで、各行の最初のセル（おてほん/なぞる/かいてみよう のラベル付き）と、それ以降のラベルなしセルで、ボックスの **上端位置がずれていた** 問題を修正。

## 原因

`Cell` コンポーネント（`NumberTracingRow.tsx`）でラベルを `{label && (...)}` の条件レンダリングにしていたため、ラベルがある場合のみラベル分の高さがflexコンテナに加わり、ラベルなしのセルは上にずれて表示されていた。

## 修正内容

ラベル div を常にレンダリングし、ラベルなしの場合は `visibility: hidden` で見た目のみ非表示にすることで、高さを確保してボックス位置を揃える。

```tsx
<div style={{
  fontSize: 9,
  color: '#6b7280',
  lineHeight: 1,
  visibility: label ? 'visible' : 'hidden',
}}>
  {label ?? ' '}
</div>
```

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- --run`（577 tests passed）
- [x] Playwright MCP で視覚確認（`.playwright-cli/tracing-aligned.png`）— 全セルがラベル有無に関わらず同じ上端位置に揃って表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)