### PR TITLE
feat(tracing): 各数字に2行目の練習マスを追加し余白を活用

### DIFF
--- a/src/components/Math/NumberTracingRow.tsx
+++ b/src/components/Math/NumberTracingRow.tsx
@@ -11,6 +11,8 @@ interface NumberTracingRowProps {
   practiceCount: number;
   /** 各セルの高さ(px)。列数に応じて親が調整する */
   cellHeight?: number;
+  /** 2行目に追加する練習マスの数。0 のときは2行目を描画しない */
+  extraPracticeCount?: number;
 }
 
 const STROKE_WIDTH = 4;
@@ -230,17 +232,19 @@ export const NumberTracingRow: React.FC<NumberTracingRowProps> = ({
   traceCount,
   practiceCount,
   cellHeight = 48,
+  extraPracticeCount = 0,
 }) => {
   return (
     <div
       style={{
         display: 'flex',
+        flexDirection: 'row',
         alignItems: 'center',
         gap: 8,
         width: '100%',
       }}
     >
-      {/* 数字ラベル */}
+      {/* 数字ラベル（2行構成のときも左側に1つだけ表示する） */}
       <div
         style={{
           fontSize: 24,
@@ -252,30 +256,64 @@ export const NumberTracingRow: React.FC<NumberTracingRowProps> = ({
       >
         {digit}
       </div>
-      {/* お手本 */}
-      <Cell size={cellHeight} label="おてほん">
-        <StrokeOrderDigit digit={digit} size={cellHeight} />
-      </Cell>
-      {/* なぞり書き */}
-      {Array.from({ length: traceCount }).map((_, i) => (
-        <Cell
-          key={`trace-${i}`}
-          size={cellHeight}
-          label={i === 0 ? 'なぞる' : undefined}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          rowGap: 8,
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        {/* 1行目: お手本 + なぞる + 自由練習 */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 8,
+          }}
         >
-          <TracingDigit digit={digit} size={cellHeight} />
-        </Cell>
-      ))}
-      {/* 自由練習 */}
-      {Array.from({ length: practiceCount }).map((_, i) => (
-        <Cell
-          key={`practice-${i}`}
-          size={cellHeight}
-          label={i === 0 ? 'かいてみよう' : undefined}
-        >
-          <PracticeBox size={cellHeight} />
-        </Cell>
-      ))}
+          <Cell size={cellHeight} label="おてほん">
+            <StrokeOrderDigit digit={digit} size={cellHeight} />
+          </Cell>
+          {Array.from({ length: traceCount }).map((_, i) => (
+            <Cell
+              key={`trace-${i}`}
+              size={cellHeight}
+              label={i === 0 ? 'なぞる' : undefined}
+            >
+              <TracingDigit digit={digit} size={cellHeight} />
+            </Cell>
+          ))}
+          {Array.from({ length: practiceCount }).map((_, i) => (
+            <Cell
+              key={`practice-${i}`}
+              size={cellHeight}
+              label={i === 0 ? 'かいてみよう' : undefined}
+            >
+              <PracticeBox size={cellHeight} />
+            </Cell>
+          ))}
+        </div>
+        {/* 2行目: 追加の自由練習マス（余白を活用） */}
+        {extraPracticeCount > 0 && (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 8,
+            }}
+          >
+            {Array.from({ length: extraPracticeCount }).map((_, i) => (
+              <Cell key={`extra-practice-${i}`} size={cellHeight}>
+                <PracticeBox size={cellHeight} />
+              </Cell>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/Math/NumberTracingRow.tsx
+++ b/src/components/Math/NumberTracingRow.tsx
@@ -4,6 +4,7 @@ import {
   DIGIT_VIEWBOX,
   type StrokeSegment,
 } from '../../lib/data/digit-strokes';
+import { NUMBER_TRACING_CELL_GAP_PX } from '../../config/number-tracing-layout';
 
 interface NumberTracingRowProps {
   digit: number;
@@ -240,7 +241,7 @@ export const NumberTracingRow: React.FC<NumberTracingRowProps> = ({
         display: 'flex',
         flexDirection: 'row',
         alignItems: 'center',
-        gap: 8,
+        gap: NUMBER_TRACING_CELL_GAP_PX,
         width: '100%',
       }}
     >
@@ -260,7 +261,7 @@ export const NumberTracingRow: React.FC<NumberTracingRowProps> = ({
         style={{
           display: 'flex',
           flexDirection: 'column',
-          rowGap: 8,
+          rowGap: NUMBER_TRACING_CELL_GAP_PX,
           flex: 1,
           minWidth: 0,
         }}
@@ -271,7 +272,7 @@ export const NumberTracingRow: React.FC<NumberTracingRowProps> = ({
             display: 'flex',
             flexDirection: 'row',
             alignItems: 'center',
-            gap: 8,
+            gap: NUMBER_TRACING_CELL_GAP_PX,
           }}
         >
           <Cell size={cellHeight} label="おてほん">
@@ -303,7 +304,7 @@ export const NumberTracingRow: React.FC<NumberTracingRowProps> = ({
               display: 'flex',
               flexDirection: 'row',
               alignItems: 'center',
-              gap: 8,
+              gap: NUMBER_TRACING_CELL_GAP_PX,
             }}
           >
             {Array.from({ length: extraPracticeCount }).map((_, i) => (

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -279,6 +279,8 @@ const NumberTracingGrid: React.FC<{ problems: Problem[] }> = ({ problems }) => {
   const cellHeight = NUMBER_TRACING_CELL_HEIGHT_PX;
   const traceCount = 2;
   const practiceCount = 1;
+  // 1問あたり2行構成にして余白を活用（4マス追加で練習量を倍増）
+  const extraPracticeCount = 4;
 
   const renderColumn = (items: NumberTracingProblem[]): React.ReactElement => (
     <div
@@ -297,6 +299,7 @@ const NumberTracingGrid: React.FC<{ problems: Problem[] }> = ({ problems }) => {
             traceCount={Math.min(p.traceCount, traceCount)}
             practiceCount={Math.min(p.practiceCount, practiceCount)}
             cellHeight={cellHeight}
+            extraPracticeCount={extraPracticeCount}
           />
         </div>
       ))}

--- a/src/config/number-tracing-layout.ts
+++ b/src/config/number-tracing-layout.ts
@@ -9,6 +9,9 @@ export const NUMBER_TRACING_CELL_HEIGHT_PX = 70;
 /** 数字ブロック間の縦ギャップ（複数の数字の間） */
 export const NUMBER_TRACING_ROW_GAP_PX = 8;
 
+/** 1問内の各セル間ギャップ（横方向のセル間／2行構成時の上下行間） */
+export const NUMBER_TRACING_CELL_GAP_PX = 8;
+
 /** 列間（左右カラム間） */
 export const NUMBER_TRACING_COL_GAP_PX = 24;
 

--- a/src/config/number-tracing-layout.ts
+++ b/src/config/number-tracing-layout.ts
@@ -6,14 +6,15 @@
 /** 左右2カラム時にA4幅へ収めるためのセル高さ */
 export const NUMBER_TRACING_CELL_HEIGHT_PX = 70;
 
-/** 行間 */
-export const NUMBER_TRACING_ROW_GAP_PX = 12;
+/** 数字ブロック間の縦ギャップ（複数の数字の間） */
+export const NUMBER_TRACING_ROW_GAP_PX = 8;
 
 /** 列間（左右カラム間） */
 export const NUMBER_TRACING_COL_GAP_PX = 24;
 
 /**
- * 行の見かけ高さ。
- * cellHeight + border/padding(6px) + ラベル(9px) + ラベル間隔(2px) ≈ 90px
+ * 1問（1つの数字ブロック）の見かけ高さ。
+ * 2行構成（1行目: お手本+なぞる+練習 / 2行目: 追加練習）。
+ * 内訳: 2行 × (cellHeight 70 + ラベル枠 11 + border/padding 6) + 内部 rowGap 8 ≒ 182px
  */
-export const NUMBER_TRACING_MIN_PROBLEM_HEIGHT_PX = 90;
+export const NUMBER_TRACING_MIN_PROBLEM_HEIGHT_PX = 182;


### PR DESCRIPTION
## Summary

数字なぞり書きプリントで A4 下部に大きな余白が残っていたため、各数字に **2行目の練習マス（4マス）** を追加して、ページ全体を有効活用しつつ練習量を倍増させました。

## Before / After

| | 1問あたりのセル | 練習マス | 余白 |
|---|---|---|---|
| Before | 4（label/お手本/trace×2/practice×1） | 1 | 約半ページ |
| After | 8（label/お手本/trace×2/practice×1 + 練習×4） | **5** | ほぼなし |

## 変更点

- `NumberTracingRow` に `extraPracticeCount` プロパティを追加
  - 1行目: お手本 + 2 trace + 1 practice（従来どおり）
  - 2行目: 4 練習マス（数字ラベル下に整列、ラベルなし）
- 数字ラベルは2行構成でも左側に1つだけ表示（縦中央揃え）
- `minProblemHeight`: `90px` → `182px`（2行構成を反映）
- 数字ブロック間の `rowGap`: `12px` → `8px`（A4内に収める）

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- --run`（577 tests passed）
- [x] Playwright MCP で視覚確認（`.playwright-cli/tracing-2rows.png`）— 全10数字が2行構成で表示、A4一枚に収まる、余白が適切に活用されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)