### PR TITLE
[codex] Improve answer line spacing

### DIFF
--- a/src/components/Math/SingaporeProblemComponent.tsx
+++ b/src/components/Math/SingaporeProblemComponent.tsx
@@ -3,6 +3,10 @@ import type { SingaporeProblem } from '../../types';
 import { BarModelDiagramComponent } from './diagrams/BarModelDiagram';
 import { NumberBondDiagramComponent } from './diagrams/NumberBondDiagram';
 import { ComparisonDiagramComponent } from './diagrams/ComparisonDiagram';
+import {
+  wordProblemAnswerRowStyle,
+  wordProblemAnswerUnderlineStyle,
+} from '../../config/styles';
 
 interface SingaporeProblemComponentProps {
   problem: SingaporeProblem;
@@ -42,24 +46,14 @@ export const SingaporeProblemComponent: React.FC<
       <div style={{ marginBottom: '2px' }}>{problemText}</div>
 
       {/* Answer line — shown for all Singapore Math categories */}
-      <div
-        style={{
-          marginTop: '4px',
-          display: 'flex',
-          alignItems: 'flex-end',
-          gap: '6px',
-          minHeight: '30px',
-        }}
-      >
+      <div style={wordProblemAnswerRowStyle}>
         <span style={{ color: '#000', fontSize: '12px' }}>Answer:</span>
         <div
           style={{
-            borderBottom: '1.5px solid #000',
+            ...wordProblemAnswerUnderlineStyle,
             flex: category === 'number-bond' ? '0 1 4rem' : '1 1 4.5rem',
             minWidth: category === 'number-bond' ? '2.5rem' : '3.5rem',
             maxWidth: category === 'number-bond' ? '5rem' : '10rem',
-            padding: '0 6px',
-            height: '24px',
           }}
         >
           {showAnswer && (

--- a/src/components/Math/SingaporeProblemComponent.tsx
+++ b/src/components/Math/SingaporeProblemComponent.tsx
@@ -48,15 +48,18 @@ export const SingaporeProblemComponent: React.FC<
           display: 'flex',
           alignItems: 'flex-end',
           gap: '6px',
+          minHeight: '30px',
         }}
       >
         <span style={{ color: '#000', fontSize: '12px' }}>Answer:</span>
         <div
           style={{
             borderBottom: '1.5px solid #000',
+            flex: category === 'number-bond' ? '0 1 4rem' : '1 1 4.5rem',
             minWidth: category === 'number-bond' ? '2.5rem' : '3.5rem',
+            maxWidth: category === 'number-bond' ? '5rem' : '10rem',
             padding: '0 6px',
-            height: '1.1em',
+            height: '24px',
           }}
         >
           {showAnswer && (

--- a/src/components/Math/WordProblemEn.tsx
+++ b/src/components/Math/WordProblemEn.tsx
@@ -24,15 +24,37 @@ export const WordProblemEnComponent: React.FC<WordProblemEnProps> = ({
   ]);
 
   return (
-    <div style={{ textAlign: 'left', fontSize: '15px', lineHeight: '1.3', color: '#000' }}>
-      <div style={{ marginBottom: '2px' }}>
-        {problem.problemText}
-      </div>
+    <div
+      style={{
+        textAlign: 'left',
+        fontSize: '15px',
+        lineHeight: '1.3',
+        color: '#000',
+      }}
+    >
+      <div style={{ marginBottom: '2px' }}>{problem.problemText}</div>
 
       {ANSWER_LINE_CATEGORIES.has(problem.category) && (
-        <div style={{ marginTop: '4px', display: 'flex', alignItems: 'flex-end', gap: '6px' }}>
+        <div
+          style={{
+            marginTop: '4px',
+            display: 'flex',
+            alignItems: 'flex-end',
+            gap: '6px',
+            minHeight: '30px',
+          }}
+        >
           <span style={{ color: '#000', fontSize: '13px' }}>Answer:</span>
-          <div style={{ borderBottom: '1.5px solid #000', minWidth: '3.5rem', padding: '0 6px', height: '1.1em' }}>
+          <div
+            style={{
+              borderBottom: '1.5px solid #000',
+              flex: '1 1 4.5rem',
+              minWidth: '3.5rem',
+              maxWidth: '10rem',
+              padding: '0 6px',
+              height: '24px',
+            }}
+          >
             {showAnswer && (
               <span style={{ fontWeight: '500', color: '#000' }}>
                 {problem.answer}

--- a/src/components/Math/WordProblemEn.tsx
+++ b/src/components/Math/WordProblemEn.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import type { WordProblemEn } from '../../types';
+import {
+  wordProblemAnswerRowStyle,
+  wordProblemAnswerUnderlineStyle,
+} from '../../config/styles';
 
 interface WordProblemEnProps {
   problem: WordProblemEn;
@@ -35,24 +39,13 @@ export const WordProblemEnComponent: React.FC<WordProblemEnProps> = ({
       <div style={{ marginBottom: '2px' }}>{problem.problemText}</div>
 
       {ANSWER_LINE_CATEGORIES.has(problem.category) && (
-        <div
-          style={{
-            marginTop: '4px',
-            display: 'flex',
-            alignItems: 'flex-end',
-            gap: '6px',
-            minHeight: '30px',
-          }}
-        >
+        <div style={wordProblemAnswerRowStyle}>
           <span style={{ color: '#000', fontSize: '13px' }}>Answer:</span>
           <div
             style={{
-              borderBottom: '1.5px solid #000',
-              flex: '1 1 4.5rem',
+              ...wordProblemAnswerUnderlineStyle,
               minWidth: '3.5rem',
               maxWidth: '10rem',
-              padding: '0 6px',
-              height: '24px',
             }}
           >
             {showAnswer && (

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -58,6 +58,9 @@ import {
   fractionDenominatorStyle,
   fractionAnswerNumeratorStyle,
   wordEnNumberStyle,
+  symbolProblemAnswerRowStyle,
+  wordProblemAnswerLabelStyle,
+  wordProblemAnswerRowStyle,
   hissanContainerStyle,
   hissanCellStyle,
   hissanAnswerBoxStyle,
@@ -568,7 +571,13 @@ function ProblemItem({
             {wordProblem.problemText}
           </div>
         )}
-        <div style={{ marginTop: SPACING.gap.small }}>
+        <div
+          style={
+            isCountingProblem
+              ? symbolProblemAnswerRowStyle
+              : wordProblemAnswerRowStyle
+          }
+        >
           {showAnswer ? (
             <span style={answerDisplayStyle}>
               答え: {wordProblem.answer}
@@ -576,7 +585,8 @@ function ProblemItem({
             </span>
           ) : (
             <>
-              答え: <span style={wordProblemAnswerUnderlineStyle} />
+              <span style={wordProblemAnswerLabelStyle}>答え:</span>
+              <span style={wordProblemAnswerUnderlineStyle} />
               {wordProblem.unit && (
                 <span style={{ fontSize: '14px' }}>{wordProblem.unit}</span>
               )}

--- a/src/config/styles.ts
+++ b/src/config/styles.ts
@@ -202,10 +202,40 @@ export const fractionAnswerUnderlineStyle: CSSProperties = {
  * 文章問題用の答え下線（さらに広め）
  */
 export const wordProblemAnswerUnderlineStyle: CSSProperties = {
-  display: 'inline-block',
-  width: '96px',
+  display: 'block',
+  flex: '1 1 120px',
+  minWidth: '96px',
+  maxWidth: '180px',
+  height: '28px',
   borderBottom: BORDERS.standard,
-  margin: '0 4px',
+  margin: '0 4px 2px',
+};
+
+/**
+ * 文章問題用の答え記入行
+ */
+export const wordProblemAnswerRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-end',
+  gap: SPACING.gap.small,
+  minHeight: '34px',
+  marginTop: SPACING.gap.small,
+};
+
+/**
+ * 記号を数える問題用の答え記入行
+ */
+export const symbolProblemAnswerRowStyle: CSSProperties = {
+  ...wordProblemAnswerRowStyle,
+  minHeight: '56px',
+  marginTop: '0',
+};
+
+/**
+ * 文章問題用の答えラベル
+ */
+export const wordProblemAnswerLabelStyle: CSSProperties = {
+  flexShrink: 0,
 };
 
 /**

--- a/src/config/styles.ts
+++ b/src/config/styles.ts
@@ -202,13 +202,15 @@ export const fractionAnswerUnderlineStyle: CSSProperties = {
  * 文章問題用の答え下線（さらに広め）
  */
 export const wordProblemAnswerUnderlineStyle: CSSProperties = {
-  display: 'block',
+  display: 'flex',
+  alignItems: 'flex-end',
   flex: '1 1 120px',
   minWidth: '96px',
   maxWidth: '180px',
   height: '28px',
   borderBottom: BORDERS.standard,
   margin: '0 4px 2px',
+  padding: '0 6px',
 };
 
 /**


### PR DESCRIPTION
## Summary

- Increase the writable area for Japanese word-problem answer lines.
- Move the answer line lower for first-grade symbol/counting problems so it uses the blank space below the prompt.
- Apply the same minimum answer-line height treatment to English word problems and Singapore Math answer lines.

## Root Cause

The affected worksheets used a narrow inline underline for answers. When symbol prompts wrapped to multiple lines, the answer area stayed too close to the prompt and left usable blank space underneath, making the writing area feel cramped.

## Validation

- `npm run typecheck`
- `npm test -- --run src/components/Export/__tests__/print-integration.test.tsx src/components/Preview/__tests__/WorksheetPreview.test.tsx`
- `npm run lint`
- `npm run build`
- Playwright spot check for `add-counting`, `counting-add`, and `counting-sub` answer-line dimensions and placement