### PR TITLE
feat: add equation line option for word problems

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,7 @@ function App(): React.ReactElement {
     settings.calculationPattern,
     settings.problemCount,
     settings.layoutColumns,
+    settings.showEquationLine,
   ]);
 
   return (
@@ -174,11 +175,15 @@ function App(): React.ReactElement {
                       layoutColumns={settings.layoutColumns}
                       problemType={settings.problemType}
                       calculationPattern={settings.calculationPattern}
+                      showEquationLine={settings.showEquationLine}
                       onProblemCountChange={(problemCount) =>
                         updateSettings({ problemCount })
                       }
                       onLayoutColumnsChange={(layoutColumns) =>
                         updateSettings({ layoutColumns })
+                      }
+                      onShowEquationLineChange={(showEquationLine) =>
+                        updateSettings({ showEquationLine })
                       }
                     />
                   </div>

--- a/src/components/Export/__tests__/print-integration.test.tsx
+++ b/src/components/Export/__tests__/print-integration.test.tsx
@@ -10,6 +10,7 @@ import type {
   MixedNumberProblem,
   WordProblem,
   WordProblemEn,
+  SingaporeProblem,
   HissanProblem,
 } from '../../../types';
 
@@ -291,6 +292,76 @@ describe('Print Integration Tests', () => {
       expect(html).toContain('cm²');
     });
 
+    it('should render equation line before answer line for word problems when enabled', () => {
+      const wordProblem: WordProblem = {
+        id: '1',
+        type: 'word',
+        operation: 'multiplication',
+        problemText: 'たて5cm、よこ3cmの長方形の面積は？',
+        answer: 15,
+        unit: 'cm²',
+      };
+
+      const { container } = render(
+        <ProblemList
+          problems={[wordProblem]}
+          layoutColumns={2}
+          showAnswers={true}
+          settings={{ ...createSettings('word'), showEquationLine: true }}
+        />
+      );
+
+      const html = container.innerHTML;
+      expect(html).toContain('式:');
+      expect(html.indexOf('式:')).toBeLessThan(html.indexOf('答え:'));
+      expect(html).toContain('15');
+    });
+
+    it('should keep current word problem layout when equation line is disabled', () => {
+      const wordProblem: WordProblem = {
+        id: '1',
+        type: 'word',
+        operation: 'addition',
+        problemText: 'りんごが3こ、みかんが2こあります。あわせて何こですか？',
+        answer: 5,
+        unit: 'こ',
+      };
+
+      const { container } = render(
+        <ProblemList
+          problems={[wordProblem]}
+          layoutColumns={2}
+          showAnswers={false}
+          settings={{ ...createSettings('word'), showEquationLine: false }}
+        />
+      );
+
+      expect(container.innerHTML).not.toContain('式:');
+    });
+
+    it('should not render equation line for basic problems even if setting remains true', () => {
+      const basicProblem: BasicProblem = {
+        id: '1',
+        type: 'basic',
+        operation: 'addition',
+        operand1: 1,
+        operand2: 2,
+        answer: 3,
+      };
+
+      const { container } = render(
+        <ProblemList
+          problems={[basicProblem]}
+          layoutColumns={2}
+          showAnswers={false}
+          settings={{ ...createSettings('basic'), showEquationLine: true }}
+        />
+      );
+
+      expect(container.innerHTML).not.toContain('式:');
+      expect(container.innerHTML).not.toContain('Equation:');
+    });
+
     it('should render missing number problems correctly', () => {
       const missingProblem: BasicProblem = {
         id: '1',
@@ -440,6 +511,64 @@ describe('Print Integration Tests', () => {
       // 問題番号が表示されているか確認
       expect(html).toContain('(1)');
       expect(html).toContain('(2)');
+    });
+
+    it('should render equation line before answer line for word-en problems when enabled', () => {
+      const problems = createWordEnProblems(1);
+      const { container } = render(
+        <ProblemList
+          problems={problems}
+          layoutColumns={2}
+          showAnswers={true}
+          settings={{
+            ...wordEnSettings,
+            problemCount: 1,
+            showEquationLine: true,
+          }}
+        />
+      );
+
+      const html = container.innerHTML;
+      expect(html).toContain('Equation:');
+      expect(html.indexOf('Equation:')).toBeLessThan(html.indexOf('Answer:'));
+      expect(html).toContain('1');
+    });
+  });
+
+  describe('Singapore Math Layout', () => {
+    const singaporeSettings: WorksheetSettings = {
+      grade: 2,
+      problemType: 'basic',
+      operation: 'addition',
+      calculationPattern: 'singapore-bar-model',
+      problemCount: 1,
+      layoutColumns: 2,
+    };
+
+    it('should render equation line before answer line for Singapore Math when enabled', () => {
+      const singaporeProblem: SingaporeProblem = {
+        id: 'sg-1',
+        type: 'singapore',
+        operation: 'addition',
+        problemText:
+          'Mia has 3 red beads and 4 blue beads. How many beads does she have?',
+        answer: 7,
+        category: 'bar-model',
+        language: 'en',
+      };
+
+      const { container } = render(
+        <ProblemList
+          problems={[singaporeProblem]}
+          layoutColumns={2}
+          showAnswers={false}
+          settings={{ ...singaporeSettings, showEquationLine: true }}
+        />
+      );
+
+      const html = container.innerHTML;
+      expect(html).toContain('Equation:');
+      expect(html.indexOf('Equation:')).toBeLessThan(html.indexOf('Answer:'));
     });
   });
 

--- a/src/components/Math/EquationLine.tsx
+++ b/src/components/Math/EquationLine.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  wordProblemAnswerLabelStyle,
+  wordProblemEquationRowStyle,
+  wordProblemEquationUnderlineStyle,
+} from '../../config/styles';
+
+interface EquationLineProps {
+  label: string;
+  labelFontSize?: string;
+  labelColor?: string;
+  minWidth?: string;
+}
+
+/**
+ * 文章問題用の式記入行を表示する共通コンポーネント
+ * 日本語文章問題、英語文章問題、シンガポール式問題で共有利用する
+ */
+export const EquationLine: React.FC<EquationLineProps> = ({
+  label,
+  labelFontSize,
+  labelColor,
+  minWidth,
+}) => (
+  <div style={wordProblemEquationRowStyle}>
+    <span
+      style={{
+        ...wordProblemAnswerLabelStyle,
+        ...(labelColor !== undefined ? { color: labelColor } : {}),
+        ...(labelFontSize !== undefined ? { fontSize: labelFontSize } : {}),
+      }}
+    >
+      {label}
+    </span>
+    <span
+      style={{
+        ...wordProblemEquationUnderlineStyle,
+        ...(minWidth !== undefined ? { minWidth } : {}),
+      }}
+    />
+  </div>
+);

--- a/src/components/Math/SingaporeProblemComponent.tsx
+++ b/src/components/Math/SingaporeProblemComponent.tsx
@@ -3,12 +3,10 @@ import type { SingaporeProblem } from '../../types';
 import { BarModelDiagramComponent } from './diagrams/BarModelDiagram';
 import { NumberBondDiagramComponent } from './diagrams/NumberBondDiagram';
 import { ComparisonDiagramComponent } from './diagrams/ComparisonDiagram';
+import { EquationLine } from './EquationLine';
 import {
-  wordProblemAnswerLabelStyle,
   wordProblemAnswerRowStyle,
   wordProblemAnswerUnderlineStyle,
-  wordProblemEquationRowStyle,
-  wordProblemEquationUnderlineStyle,
 } from '../../config/styles';
 
 interface SingaporeProblemComponentProps {
@@ -50,23 +48,12 @@ export const SingaporeProblemComponent: React.FC<
       <div style={{ marginBottom: '2px' }}>{problemText}</div>
 
       {showEquationLine && (
-        <div style={wordProblemEquationRowStyle}>
-          <span
-            style={{
-              ...wordProblemAnswerLabelStyle,
-              color: '#000',
-              fontSize: '12px',
-            }}
-          >
-            Equation:
-          </span>
-          <span
-            style={{
-              ...wordProblemEquationUnderlineStyle,
-              minWidth: category === 'number-bond' ? '2.5rem' : '3.5rem',
-            }}
-          />
-        </div>
+        <EquationLine
+          label="Equation:"
+          labelColor="#000"
+          labelFontSize="12px"
+          minWidth={category === 'number-bond' ? '2.5rem' : '3.5rem'}
+        />
       )}
 
       {/* Answer line — shown for all Singapore Math categories */}

--- a/src/components/Math/SingaporeProblemComponent.tsx
+++ b/src/components/Math/SingaporeProblemComponent.tsx
@@ -4,18 +4,22 @@ import { BarModelDiagramComponent } from './diagrams/BarModelDiagram';
 import { NumberBondDiagramComponent } from './diagrams/NumberBondDiagram';
 import { ComparisonDiagramComponent } from './diagrams/ComparisonDiagram';
 import {
+  wordProblemAnswerLabelStyle,
   wordProblemAnswerRowStyle,
   wordProblemAnswerUnderlineStyle,
+  wordProblemEquationRowStyle,
+  wordProblemEquationUnderlineStyle,
 } from '../../config/styles';
 
 interface SingaporeProblemComponentProps {
   problem: SingaporeProblem;
   showAnswer?: boolean;
+  showEquationLine?: boolean;
 }
 
 export const SingaporeProblemComponent: React.FC<
   SingaporeProblemComponentProps
-> = ({ problem, showAnswer = false }) => {
+> = ({ problem, showAnswer = false, showEquationLine = false }) => {
   const { diagram, problemText, answer, unit, category } = problem;
 
   return (
@@ -44,6 +48,26 @@ export const SingaporeProblemComponent: React.FC<
 
       {/* Problem text */}
       <div style={{ marginBottom: '2px' }}>{problemText}</div>
+
+      {showEquationLine && (
+        <div style={wordProblemEquationRowStyle}>
+          <span
+            style={{
+              ...wordProblemAnswerLabelStyle,
+              color: '#000',
+              fontSize: '12px',
+            }}
+          >
+            Equation:
+          </span>
+          <span
+            style={{
+              ...wordProblemEquationUnderlineStyle,
+              minWidth: category === 'number-bond' ? '2.5rem' : '3.5rem',
+            }}
+          />
+        </div>
+      )}
 
       {/* Answer line — shown for all Singapore Math categories */}
       <div style={wordProblemAnswerRowStyle}>

--- a/src/components/Math/WordProblemEn.tsx
+++ b/src/components/Math/WordProblemEn.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import type { WordProblemEn } from '../../types';
 import {
+  wordProblemAnswerLabelStyle,
   wordProblemAnswerRowStyle,
   wordProblemAnswerUnderlineStyle,
+  wordProblemEquationRowStyle,
+  wordProblemEquationUnderlineStyle,
 } from '../../config/styles';
 
 interface WordProblemEnProps {
   problem: WordProblemEn;
   showAnswer?: boolean;
+  showEquationLine?: boolean;
 }
 
 /**
@@ -17,6 +21,7 @@ interface WordProblemEnProps {
 export const WordProblemEnComponent: React.FC<WordProblemEnProps> = ({
   problem,
   showAnswer = false,
+  showEquationLine = false,
 }) => {
   const ANSWER_LINE_CATEGORIES = new Set([
     'word-story',
@@ -39,23 +44,44 @@ export const WordProblemEnComponent: React.FC<WordProblemEnProps> = ({
       <div style={{ marginBottom: '2px' }}>{problem.problemText}</div>
 
       {ANSWER_LINE_CATEGORIES.has(problem.category) && (
-        <div style={wordProblemAnswerRowStyle}>
-          <span style={{ color: '#000', fontSize: '13px' }}>Answer:</span>
-          <div
-            style={{
-              ...wordProblemAnswerUnderlineStyle,
-              minWidth: '3.5rem',
-              maxWidth: '10rem',
-            }}
-          >
-            {showAnswer && (
-              <span style={{ fontWeight: '500', color: '#000' }}>
-                {problem.answer}
-                {problem.unit && ` ${problem.unit}`}
+        <>
+          {showEquationLine && (
+            <div style={wordProblemEquationRowStyle}>
+              <span
+                style={{
+                  ...wordProblemAnswerLabelStyle,
+                  color: '#000',
+                  fontSize: '13px',
+                }}
+              >
+                Equation:
               </span>
-            )}
+              <span
+                style={{
+                  ...wordProblemEquationUnderlineStyle,
+                  minWidth: '3.5rem',
+                }}
+              />
+            </div>
+          )}
+          <div style={wordProblemAnswerRowStyle}>
+            <span style={{ color: '#000', fontSize: '13px' }}>Answer:</span>
+            <div
+              style={{
+                ...wordProblemAnswerUnderlineStyle,
+                minWidth: '3.5rem',
+                maxWidth: '10rem',
+              }}
+            >
+              {showAnswer && (
+                <span style={{ fontWeight: '500', color: '#000' }}>
+                  {problem.answer}
+                  {problem.unit && ` ${problem.unit}`}
+                </span>
+              )}
+            </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/src/components/Math/WordProblemEn.tsx
+++ b/src/components/Math/WordProblemEn.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import type { WordProblemEn } from '../../types';
+import { EquationLine } from './EquationLine';
 import {
-  wordProblemAnswerLabelStyle,
   wordProblemAnswerRowStyle,
   wordProblemAnswerUnderlineStyle,
-  wordProblemEquationRowStyle,
-  wordProblemEquationUnderlineStyle,
 } from '../../config/styles';
 
 interface WordProblemEnProps {
@@ -46,23 +44,12 @@ export const WordProblemEnComponent: React.FC<WordProblemEnProps> = ({
       {ANSWER_LINE_CATEGORIES.has(problem.category) && (
         <>
           {showEquationLine && (
-            <div style={wordProblemEquationRowStyle}>
-              <span
-                style={{
-                  ...wordProblemAnswerLabelStyle,
-                  color: '#000',
-                  fontSize: '13px',
-                }}
-              >
-                Equation:
-              </span>
-              <span
-                style={{
-                  ...wordProblemEquationUnderlineStyle,
-                  minWidth: '3.5rem',
-                }}
-              />
-            </div>
+            <EquationLine
+              label="Equation:"
+              labelColor="#000"
+              labelFontSize="13px"
+              minWidth="3.5rem"
+            />
           )}
           <div style={wordProblemAnswerRowStyle}>
             <span style={{ color: '#000', fontSize: '13px' }}>Answer:</span>

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -61,6 +61,8 @@ import {
   symbolProblemAnswerRowStyle,
   wordProblemAnswerLabelStyle,
   wordProblemAnswerRowStyle,
+  wordProblemEquationRowStyle,
+  wordProblemEquationUnderlineStyle,
   hissanContainerStyle,
   hissanCellStyle,
   hissanAnswerBoxStyle,
@@ -146,14 +148,19 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
 
     // 動的余白の計算（印刷プレビューと同じロジック）
     // A4サイズオーバーフロー判定
+    // テンプレートから gap を取得
+    const template = getPrintTemplate(effectiveProblemType);
+    const showEquationLine =
+      settings.showEquationLine === true &&
+      (effectiveProblemType === 'word' ||
+        effectiveProblemType === 'word-en' ||
+        effectiveProblemType === 'singapore');
     const a4FitResult = estimateA4Fit(
       problems.length,
       layoutColumns,
-      effectiveProblemType
+      effectiveProblemType,
+      showEquationLine
     );
-
-    // テンプレートから gap を取得
-    const template = getPrintTemplate(effectiveProblemType);
     // A4に収まる場合は align-content: space-between で行間を自動拡張し余白を均等配分
     const gridGapStyle: React.CSSProperties = {
       display: 'grid',
@@ -228,6 +235,7 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
                       problem={problem}
                       number={originalNumber}
                       showAnswer={showAnswers}
+                      showEquationLine={showEquationLine}
                     />
                   </div>
                 );
@@ -405,16 +413,25 @@ const PartialProductBoxes: React.FC<{
   );
 };
 
+const EquationLine: React.FC<{ label: string }> = ({ label }) => (
+  <div style={wordProblemEquationRowStyle}>
+    <span style={wordProblemAnswerLabelStyle}>{label}</span>
+    <span style={wordProblemEquationUnderlineStyle} />
+  </div>
+);
+
 interface ProblemItemProps {
   problem: Problem;
   number: number;
   showAnswer?: boolean;
+  showEquationLine?: boolean;
 }
 
 function ProblemItem({
   problem,
   number,
   showAnswer = false,
+  showEquationLine = false,
 }: ProblemItemProps): React.ReactElement {
   const operationSymbol = {
     addition: '+',
@@ -571,6 +588,7 @@ function ProblemItem({
             {wordProblem.problemText}
           </div>
         )}
+        {showEquationLine && <EquationLine label="式:" />}
         <div
           style={
             isCountingProblem
@@ -614,6 +632,7 @@ function ProblemItem({
           <WordProblemEnComponent
             problem={wordProblemEn}
             showAnswer={showAnswer}
+            showEquationLine={showEquationLine}
           />
         </div>
       </div>
@@ -637,6 +656,7 @@ function ProblemItem({
           <SingaporeProblemComponent
             problem={sgProblem}
             showAnswer={showAnswer}
+            showEquationLine={showEquationLine}
           />
         </div>
       </div>

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../lib/utils/missing-number-calculator';
 import { WordProblemEnComponent } from '../Math/WordProblemEn';
 import { SingaporeProblemComponent } from '../Math/SingaporeProblemComponent';
+import { EquationLine } from '../Math/EquationLine';
 import { NumberTracingRow } from '../Math/NumberTracingRow';
 import type { NumberTracingProblem } from '../../types';
 import { getPrintTemplate } from '../../config/print-templates';
@@ -29,7 +30,10 @@ import {
   NUMBER_TRACING_COL_GAP_PX,
   NUMBER_TRACING_ROW_GAP_PX,
 } from '../../config/number-tracing-layout';
-import { getEffectiveProblemType } from '../../lib/utils/problem-type-detector';
+import {
+  getEffectiveProblemType,
+  supportsEquationLine,
+} from '../../lib/utils/problem-type-detector';
 import { estimateA4Fit } from '../../lib/utils/print-validator';
 import { buildPreviewTitle } from '../../lib/utils/previewTitle';
 import {
@@ -61,8 +65,6 @@ import {
   symbolProblemAnswerRowStyle,
   wordProblemAnswerLabelStyle,
   wordProblemAnswerRowStyle,
-  wordProblemEquationRowStyle,
-  wordProblemEquationUnderlineStyle,
   hissanContainerStyle,
   hissanCellStyle,
   hissanAnswerBoxStyle,
@@ -152,9 +154,7 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
     const template = getPrintTemplate(effectiveProblemType);
     const showEquationLine =
       settings.showEquationLine === true &&
-      (effectiveProblemType === 'word' ||
-        effectiveProblemType === 'word-en' ||
-        effectiveProblemType === 'singapore');
+      supportsEquationLine(effectiveProblemType);
     const a4FitResult = estimateA4Fit(
       problems.length,
       layoutColumns,
@@ -412,13 +412,6 @@ const PartialProductBoxes: React.FC<{
     </>
   );
 };
-
-const EquationLine: React.FC<{ label: string }> = ({ label }) => (
-  <div style={wordProblemEquationRowStyle}>
-    <span style={wordProblemAnswerLabelStyle}>{label}</span>
-    <span style={wordProblemEquationUnderlineStyle} />
-  </div>
-);
 
 interface ProblemItemProps {
   problem: Problem;

--- a/src/components/ProblemGenerator/SettingsPanel.tsx
+++ b/src/components/ProblemGenerator/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   isWordEnProblem,
   isWordProblem,
   getEffectiveProblemType,
+  supportsEquationLine,
 } from '../../lib/utils/problem-type-detector';
 
 interface SettingsPanelProps {
@@ -47,10 +48,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const template = getPrintTemplate(effectiveProblemType);
   const isAnzan = effectiveProblemType === 'anzan';
   const isNumberTracing = effectiveProblemType === 'number-tracing';
-  const supportsEquationLine =
-    effectiveProblemType === 'word' ||
-    effectiveProblemType === 'word-en' ||
-    effectiveProblemType === 'singapore';
+  const showEquationLineToggle = supportsEquationLine(effectiveProblemType);
 
   // 列数に応じた最大問題数と推奨問題数を取得（パターン固有オーバーライド対応）
   const patternOverride = calculationPattern
@@ -315,7 +313,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
         )}
       </div>
 
-      {supportsEquationLine && (
+      {showEquationLineToggle && (
         <div className="rounded-2xl border border-sky-100 bg-slate-50/80 p-3">
           <label className="flex items-center justify-between gap-4 text-sm text-slate-700">
             <span className="font-semibold">式を書く欄</span>

--- a/src/components/ProblemGenerator/SettingsPanel.tsx
+++ b/src/components/ProblemGenerator/SettingsPanel.tsx
@@ -19,8 +19,10 @@ interface SettingsPanelProps {
   layoutColumns: LayoutColumns;
   problemType?: ProblemType;
   calculationPattern?: CalculationPattern;
+  showEquationLine?: boolean;
   onProblemCountChange: (count: number) => void;
   onLayoutColumnsChange: (columns: LayoutColumns) => void;
+  onShowEquationLineChange: (show: boolean) => void;
 }
 
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({
@@ -28,8 +30,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   layoutColumns,
   problemType,
   calculationPattern,
+  showEquationLine = false,
   onProblemCountChange,
   onLayoutColumnsChange,
+  onShowEquationLineChange,
 }) => {
   // 問題タイプの判定
   const isWordEn = isWordEnProblem(calculationPattern);
@@ -43,6 +47,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const template = getPrintTemplate(effectiveProblemType);
   const isAnzan = effectiveProblemType === 'anzan';
   const isNumberTracing = effectiveProblemType === 'number-tracing';
+  const supportsEquationLine =
+    effectiveProblemType === 'word' ||
+    effectiveProblemType === 'word-en' ||
+    effectiveProblemType === 'singapore';
 
   // 列数に応じた最大問題数と推奨問題数を取得（パターン固有オーバーライド対応）
   const patternOverride = calculationPattern
@@ -306,6 +314,23 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           </p>
         )}
       </div>
+
+      {supportsEquationLine && (
+        <div className="rounded-2xl border border-sky-100 bg-slate-50/80 p-3">
+          <label className="flex items-center justify-between gap-4 text-sm text-slate-700">
+            <span className="font-semibold">式を書く欄</span>
+            <input
+              type="checkbox"
+              checked={showEquationLine}
+              onChange={(e) => onShowEquationLineChange(e.target.checked)}
+              className="h-4 w-4 rounded border-sky-300 text-sky-500 focus:ring-sky-400"
+            />
+          </label>
+          <p className="mt-1 text-xs text-slate-500">
+            文章から数量関係を読み取って式を書く練習欄を追加します
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/ProblemGenerator/__tests__/SettingsPanel.test.tsx
+++ b/src/components/ProblemGenerator/__tests__/SettingsPanel.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SettingsPanel } from '../SettingsPanel';
+
+const baseProps = {
+  problemCount: 16,
+  layoutColumns: 2 as const,
+  onProblemCountChange: vi.fn(),
+  onLayoutColumnsChange: vi.fn(),
+  onShowEquationLineChange: vi.fn(),
+};
+
+describe('SettingsPanel equation line option', () => {
+  it('shows equation line toggle for Japanese word problems', () => {
+    render(
+      <SettingsPanel
+        {...baseProps}
+        problemType="word"
+        calculationPattern={undefined}
+      />
+    );
+
+    expect(screen.getByLabelText('式を書く欄')).toBeInTheDocument();
+  });
+
+  it('shows equation line toggle for Singapore Math patterns', () => {
+    render(
+      <SettingsPanel
+        {...baseProps}
+        problemType="basic"
+        calculationPattern="singapore-bar-model"
+      />
+    );
+
+    expect(screen.getByLabelText('式を書く欄')).toBeInTheDocument();
+  });
+
+  it('does not show equation line toggle for basic calculation problems', () => {
+    render(
+      <SettingsPanel
+        {...baseProps}
+        problemType="basic"
+        calculationPattern="add-single-digit"
+      />
+    );
+
+    expect(screen.queryByLabelText('式を書く欄')).not.toBeInTheDocument();
+  });
+
+  it('notifies when the equation line toggle changes', () => {
+    const onShowEquationLineChange = vi.fn();
+    render(
+      <SettingsPanel
+        {...baseProps}
+        problemType="word"
+        calculationPattern={undefined}
+        onShowEquationLineChange={onShowEquationLineChange}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('式を書く欄'));
+
+    expect(onShowEquationLineChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/config/styles.ts
+++ b/src/config/styles.ts
@@ -241,6 +241,24 @@ export const wordProblemAnswerLabelStyle: CSSProperties = {
 };
 
 /**
+ * 文章問題用の式記入行
+ */
+export const wordProblemEquationRowStyle: CSSProperties = {
+  ...wordProblemAnswerRowStyle,
+  minHeight: '30px',
+  marginTop: '2px',
+};
+
+/**
+ * 文章問題用の式下線
+ */
+export const wordProblemEquationUnderlineStyle: CSSProperties = {
+  ...wordProblemAnswerUnderlineStyle,
+  maxWidth: 'none',
+  height: '24px',
+};
+
+/**
  * 答え表示スタイル（赤字・太字）
  */
 export const answerDisplayStyle: CSSProperties = {

--- a/src/lib/utils/__tests__/url-state.test.ts
+++ b/src/lib/utils/__tests__/url-state.test.ts
@@ -104,6 +104,16 @@ describe('parseUrlSettings', () => {
     expect(result.layoutColumns).toBe(2);
     expect(result.problemCount).toBe(10);
   });
+
+  it('parses equation line flag for word problem settings', () => {
+    const result = parseUrlSettings('?type=word&eq=1', defaults);
+    expect(result.showEquationLine).toBe(true);
+  });
+
+  it('ignores equation line flag for non-word problem settings', () => {
+    const result = parseUrlSettings('?type=basic&eq=1', defaults);
+    expect(result.showEquationLine).toBeUndefined();
+  });
 });
 
 describe('settingsToUrlParams', () => {
@@ -128,6 +138,21 @@ describe('settingsToUrlParams', () => {
   it('does not include operation in URL', () => {
     const params = settingsToUrlParams(defaults);
     expect(params).not.toContain('operation=');
+  });
+
+  it('serializes equation line flag only for word problem settings', () => {
+    const wordParams = settingsToUrlParams({
+      ...defaults,
+      problemType: 'word',
+      showEquationLine: true,
+    });
+    expect(wordParams).toContain('eq=1');
+
+    const basicParams = settingsToUrlParams({
+      ...defaults,
+      showEquationLine: true,
+    });
+    expect(basicParams).not.toContain('eq=');
   });
 });
 

--- a/src/lib/utils/print-validator.ts
+++ b/src/lib/utils/print-validator.ts
@@ -6,6 +6,13 @@
 
 import type { ProblemType, LayoutColumns } from '../../types';
 import { getPrintTemplate } from '../../config/print-templates';
+import { supportsEquationLine } from './problem-type-detector';
+
+/**
+ * 式記入行の高さ（mm）
+ * estimateA4Fit でレイアウト計算に使用
+ */
+export const EQUATION_LINE_HEIGHT_MM = 8;
 
 /**
  * 生成されたHTMLから問題番号をカウントする
@@ -43,7 +50,10 @@ export function countProblemsInHTML(html: string): number {
  * }
  * ```
  */
-export function validateProblemType(html: string, problemType: ProblemType): boolean {
+export function validateProblemType(
+  html: string,
+  problemType: ProblemType
+): boolean {
   switch (problemType) {
     case 'fraction':
       // MathMLの分数タグを確認
@@ -105,11 +115,8 @@ export function estimateA4Fit(
 
   // 問題タイプごとの推定高さ（mm）
   const equationLineHeightMm =
-    showEquationLine &&
-    (problemType === 'word' ||
-      problemType === 'word-en' ||
-      problemType === 'singapore')
-      ? 8
+    showEquationLine && supportsEquationLine(problemType)
+      ? EQUATION_LINE_HEIGHT_MM
       : 0;
   const minProblemHeightMm =
     parseInt(template.layout.minProblemHeight) * 0.26 + equationLineHeightMm; // px to mm (96dpi)
@@ -119,7 +126,8 @@ export function estimateA4Fit(
   const headerHeight = 25; // ヘッダー部分の高さ (mm)
   const verticalMarginMin = 5; // 最小余白 (mm)
 
-  const contentHeight = headerHeight + (minProblemHeightMm + rowGapMm) * rowCount;
+  const contentHeight =
+    headerHeight + (minProblemHeightMm + rowGapMm) * rowCount;
   const estimatedHeight = contentHeight + verticalMarginMin * 2;
 
   const a4Height = 297; // A4の高さ (mm)

--- a/src/lib/utils/print-validator.ts
+++ b/src/lib/utils/print-validator.ts
@@ -97,13 +97,22 @@ export function validateProblemType(html: string, problemType: ProblemType): boo
 export function estimateA4Fit(
   problemCount: number,
   layoutColumns: LayoutColumns,
-  problemType: ProblemType
+  problemType: ProblemType,
+  showEquationLine: boolean = false
 ): { fits: boolean; estimatedHeight: number; a4Height: number } {
   const template = getPrintTemplate(problemType);
   const rowCount = Math.ceil(problemCount / layoutColumns);
 
   // 問題タイプごとの推定高さ（mm）
-  const minProblemHeightMm = parseInt(template.layout.minProblemHeight) * 0.26; // px to mm (96dpi)
+  const equationLineHeightMm =
+    showEquationLine &&
+    (problemType === 'word' ||
+      problemType === 'word-en' ||
+      problemType === 'singapore')
+      ? 8
+      : 0;
+  const minProblemHeightMm =
+    parseInt(template.layout.minProblemHeight) * 0.26 + equationLineHeightMm; // px to mm (96dpi)
   const rowGapMm = parseInt(template.layout.rowGap) * 0.26;
 
   // 必要な高さを計算

--- a/src/lib/utils/problem-type-detector.test.ts
+++ b/src/lib/utils/problem-type-detector.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getEffectiveProblemType,
   isWordProblem,
+  supportsEquationLine,
 } from './problem-type-detector';
 
 describe('problem-type-detector allowance classification', () => {
@@ -73,8 +74,26 @@ describe('problem-type-detector explicit problem type priority', () => {
     expect(getEffectiveProblemType('basic', 'frac-same-denom')).toBe(
       'fraction'
     );
-    expect(getEffectiveProblemType('basic', 'frac-mixed-number')).toBe(
-      'mixed'
-    );
+    expect(getEffectiveProblemType('basic', 'frac-mixed-number')).toBe('mixed');
+  });
+});
+
+describe('supportsEquationLine', () => {
+  it('returns true for word problem types', () => {
+    expect(supportsEquationLine('word')).toBe(true);
+    expect(supportsEquationLine('word-en')).toBe(true);
+    expect(supportsEquationLine('singapore')).toBe(true);
+  });
+
+  it('returns false for non-word problem types', () => {
+    expect(supportsEquationLine('basic')).toBe(false);
+    expect(supportsEquationLine('fraction')).toBe(false);
+    expect(supportsEquationLine('decimal')).toBe(false);
+    expect(supportsEquationLine('mixed')).toBe(false);
+    expect(supportsEquationLine('hissan')).toBe(false);
+    expect(supportsEquationLine('hissan-div')).toBe(false);
+    expect(supportsEquationLine('missing')).toBe(false);
+    expect(supportsEquationLine('anzan')).toBe(false);
+    expect(supportsEquationLine('number-tracing')).toBe(false);
   });
 });

--- a/src/lib/utils/problem-type-detector.ts
+++ b/src/lib/utils/problem-type-detector.ts
@@ -64,6 +64,18 @@ export function isDivisionHissanProblem(
 }
 
 /**
+ * 式記入行（Equation line）をサポートする問題タイプかどうかを判定
+ * 文章問題（日本語・英語）とシンガポール式問題で利用可能
+ */
+export function supportsEquationLine(effectiveType: ProblemType): boolean {
+  return (
+    effectiveType === 'word' ||
+    effectiveType === 'word-en' ||
+    effectiveType === 'singapore'
+  );
+}
+
+/**
  * 問題タイプと計算パターンから実効的な問題タイプを取得
  * 計算パターンによって実際の問題タイプが変わる場合に使用
  */

--- a/src/lib/utils/url-state.ts
+++ b/src/lib/utils/url-state.ts
@@ -7,7 +7,10 @@ import type {
 } from '../../types';
 import { PATTERN_LABELS } from '../../types';
 import { getPrintTemplate } from '../../config/print-templates';
-import { getEffectiveProblemType } from './problem-type-detector';
+import {
+  getEffectiveProblemType,
+  supportsEquationLine as supportsEquationLineForType,
+} from './problem-type-detector';
 
 const VALID_GRADES: readonly number[] = [0, 1, 2, 3, 4, 5, 6];
 const VALID_PROBLEM_TYPES: readonly string[] = [
@@ -30,11 +33,7 @@ function supportsEquationLine(settings: Partial<WorksheetSettings>): boolean {
     settings.problemType,
     settings.calculationPattern
   );
-  return (
-    effectiveType === 'word' ||
-    effectiveType === 'word-en' ||
-    effectiveType === 'singapore'
-  );
+  return supportsEquationLineForType(effectiveType);
 }
 
 export function getOperationFromPattern(

--- a/src/lib/utils/url-state.ts
+++ b/src/lib/utils/url-state.ts
@@ -25,6 +25,18 @@ const VALID_PROBLEM_TYPES: readonly string[] = [
 ];
 const VALID_COLUMNS: readonly number[] = [1, 2, 3];
 
+function supportsEquationLine(settings: Partial<WorksheetSettings>): boolean {
+  const effectiveType = getEffectiveProblemType(
+    settings.problemType,
+    settings.calculationPattern
+  );
+  return (
+    effectiveType === 'word' ||
+    effectiveType === 'word-en' ||
+    effectiveType === 'singapore'
+  );
+}
+
 export function getOperationFromPattern(
   pattern: CalculationPattern
 ): WorksheetSettings['operation'] {
@@ -89,6 +101,12 @@ export function parseUrlSettings(
     }
   }
 
+  const equationParam = params.get('eq');
+  if (equationParam !== null && supportsEquationLine(result)) {
+    result.showEquationLine =
+      equationParam === '1' || equationParam.toLowerCase() === 'true';
+  }
+
   return result;
 }
 
@@ -101,6 +119,9 @@ export function settingsToUrlParams(settings: WorksheetSettings): string {
   }
   params.set('cols', String(settings.layoutColumns));
   params.set('count', String(settings.problemCount));
+  if (settings.showEquationLine && supportsEquationLine(settings)) {
+    params.set('eq', '1');
+  }
   return params.toString();
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -238,6 +238,7 @@ export interface WorksheetSettings {
   calculationPattern?: CalculationPattern;
   problemCount: number;
   layoutColumns: LayoutColumns;
+  showEquationLine?: boolean;
   title?: string;
   studentName?: string;
   date?: string;


### PR DESCRIPTION
## 概要

文章題で立式の練習ができるように、文章題系パターンだけに「式を書く欄」トグルを追加しました。トグルON時は日本語文章題・英語文章題・Singapore Math の各問題で、答え欄の前に式欄を表示します。

Closes #67

## 変更内容

- `WorksheetSettings` に `showEquationLine` を追加し、設定UIから切り替えられるようにしました。
- 日本語文章題・英語文章題・Singapore Math の表示コンポーネントで、式欄を答え欄の前へ条件付き描画しました。
- URL state に `eq=1` を追加し、文章題系でのみ式欄設定を復元・共有できるようにしました。
- 式欄ON時のA4高さ推定を `estimateA4Fit` に反映しました。
- 設定UI、URL state、プレビュー描画の回帰テストを追加しました。

## 動作確認 (Verification)

| 項目 | コマンド | 結果 |
| ---- | -------- | ---- |
| Build | `npm run build` | ✅ pass |
| Lint | `npm run lint` | ✅ 0 errors |
| Format | `npm run format:check` | ❌ fail: 既存の未整形ファイル44件が残存 |
| Typecheck | `npm run typecheck` | ✅ pass |
| Unit test | `npm test -- --run` | ✅ 596 passed |
| Targeted test | `npm test -- --run src/components/ProblemGenerator/__tests__/SettingsPanel.test.tsx src/components/Export/__tests__/print-integration.test.tsx src/lib/utils/__tests__/url-state.test.ts` | ✅ 52 passed |
| Layout check | `npm run check:layout:local` | ✅ 全シナリオ A4 1ページ |

実行ログ要約: lint / typecheck / test / build / layout check は成功しました。`format:check` はこのPRで触っていない既存ファイルを含む44件の未整形で失敗しています。全体 `npm run format` はスコープ外差分が大きいため実行していません。補足の式欄ON直接Playwright計測は sandbox の Chromium MachPort 権限エラーで未完了です。

## 受け入れ条件 (Acceptance Criteria)

- [x] 文章題系パターンでのみ有効な「式を書く欄」トグルを設定UIに追加できる → `SettingsPanel` で `word` / `word-en` / `singapore` の実効タイプのみ表示
- [x] トグルON時、日本語文章題・英語文章題・Singapore Math 問題の各問題に「式」欄が答え欄の前に表示される → `ProblemList` / `WordProblemEn` / `SingaporeProblemComponent` とテストで確認
- [x] トグルOFF時は現状のレイアウトと表示を維持する → OFF時に式欄が出ないテストを追加
- [x] 1列/2列/3列レイアウトと複数の文章題パターンで、A4印刷プレビューが大きく崩れない → A4推定へ式欄高さを反映し、既存レイアウトチェックは pass。式欄ONの直接ブラウザ計測は sandbox 権限で未完了
- [x] 既存の answer 表示トグルとの挙動が衝突しない → `showAnswers=true` でも式欄が空欄のまま答え欄の前に出るテストを追加
- [x] 既存テストが通り、必要なテストが追加されること → `npm test -- --run` で 596 passed

## スコープ外 (Non-goals)

- 式の自動生成や正誤判定は行いません。
- 文章題以外の通常計算・虫食い算・筆算には式欄を追加しません。
- 既存未整形ファイル44件の一括フォーマットはこのPRでは扱いません。

## 影響範囲 / リスク

- 影響API: `WorksheetSettings` に任意プロパティ `showEquationLine` を追加。既存設定は未指定で従来どおり動作します。
- 互換性: URL に `eq=1` を追加しますが、true時かつ文章題系のみ出力するため既存URLは後方互換です。
- レイアウト: 式欄ON時は各問題の高さが増えるため、A4推定に追加高さを加味しました。
- ロールバック: このコミットを `git revert` すれば既存表示へ戻せます。

## レビュー観点 (Review Focus)

- `src/components/ProblemGenerator/SettingsPanel.tsx:L318` — トグル表示対象が文章題系だけに限定できているか
- `src/components/Preview/ProblemList.tsx:L153` — 設定フラグと実効問題タイプの組み合わせが表示層へ正しく伝わるか
- `src/lib/utils/url-state.ts:L104` — `eq=1` のURL永続化が既存URL互換を崩していないか

## スクリーンショット / 出力例

```text
式: ______________________
答え: ____________________ cm²

Equation: ________________
Answer: __________________
```

---

Generated by Codex auto-resolve / Reviewed by knishioka-pm