### PR TITLE
feat(word-en): align English word problems with elementary curriculum

### DIFF
--- a/src/lib/generators/property-tests.test.ts
+++ b/src/lib/generators/property-tests.test.ts
@@ -109,9 +109,16 @@ describe('property-based tests: English Word Problems', () => {
     for (const p of problems) {
       expect(p.type).toBe('word-en');
       expect(p.problemText.trim().length).toBeGreaterThan(0);
-      expect(typeof p.answer).toBe('number');
-      expect(Number.isFinite(p.answer as number)).toBe(true);
-      expect(p.answer).toBeGreaterThan(0);
+      expect(['number', 'string']).toContain(typeof p.answer);
+      if (typeof p.answer === 'number') {
+        expect(Number.isFinite(p.answer)).toBe(true);
+        expect(p.answer).toBeGreaterThan(0);
+      } else {
+        // Curriculum-aligned templates (fractions, decimals, remainders) may
+        // return formatted strings — ensure they are non-empty and well-shaped.
+        expect(p.answer.length).toBeGreaterThan(0);
+        expect(p.answer).toMatch(/^[\d./ R-]+$/);
+      }
     }
   });
 });

--- a/src/lib/generators/templates/en-word-story.ts
+++ b/src/lib/generators/templates/en-word-story.ts
@@ -8,7 +8,7 @@ import type { Operation } from '../../../types';
 export interface WordStoryTemplate {
   generateProblem: (grade: number) => {
     text: string;
-    answer: number;
+    answer: number | string;
     operation: Operation;
   };
   minGrade: number;
@@ -255,18 +255,65 @@ function gradeRandomInt(
 /**
  * Per-grade scalar (e.g. for max factor in multiplication / division).
  * Lets us replace inline ternaries with a single readable call.
+ * Grade 3 is its own tier so curriculum-appropriate ranges can diverge from G1-2.
  */
 function gradeFactor(
   grade: number,
-  g3OrBelow: number,
+  g1to2: number,
+  g3: number,
   g4: number,
   g5: number,
   g6: number
 ): number {
-  if (grade <= 3) return g3OrBelow;
+  if (grade <= 2) return g1to2;
+  if (grade === 3) return g3;
   if (grade === 4) return g4;
   if (grade === 5) return g5;
   return g6;
+}
+
+/**
+ * Greatest common divisor for fraction reduction.
+ */
+function gcd(a: number, b: number): number {
+  const aAbs = Math.abs(a);
+  const bAbs = Math.abs(b);
+  if (bAbs === 0) return aAbs;
+  return gcd(bAbs, aAbs % bAbs);
+}
+
+/**
+ * Reduce a fraction to lowest terms.
+ */
+function reduceFraction(n: number, d: number): { n: number; d: number } {
+  if (d === 0) return { n, d };
+  const g = gcd(n, d);
+  return { n: n / g, d: d / g };
+}
+
+/**
+ * Format a fraction as a plain string. Returns "n" when denominator is 1.
+ */
+function formatFraction(n: number, d: number): string {
+  if (d === 1) return String(n);
+  return `${n}/${d}`;
+}
+
+/**
+ * Format a decimal value, trimming trailing zeros (but keeping at least one
+ * digit after the point when the value is non-integer).
+ */
+function formatDecimal(value: number, places: number): string {
+  const fixed = value.toFixed(places);
+  if (!fixed.includes('.')) return fixed;
+  return fixed.replace(/0+$/, '').replace(/\.$/, '');
+}
+
+/**
+ * Format "quotient remainder" answers. Returns just the quotient when r === 0.
+ */
+function formatRemainder(q: number, r: number): string {
+  return r === 0 ? String(q) : `${q} R ${r}`;
 }
 
 function generateFriendlyPayment(price: number, maxPaid: number): number {
@@ -375,7 +422,7 @@ export const SIMPLE_ADDITION_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 1,
-    maxGrade: 6,
+    maxGrade: 3,
     category: 'word-story',
   },
   {
@@ -412,7 +459,7 @@ export const SIMPLE_ADDITION_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 1,
-    maxGrade: 6,
+    maxGrade: 3,
     category: 'word-story',
   },
 ];
@@ -458,7 +505,7 @@ export const MULTI_STEP_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 2,
-    maxGrade: 6,
+    maxGrade: 4,
     category: 'word-story',
   },
   {
@@ -515,7 +562,7 @@ export const MULTIPLICATION_STORIES: WordStoryTemplate[] = [
   {
     generateProblem: (grade) => {
       const item = getRandomItem(true);
-      const factorMax = gradeFactor(grade, 9, 20, 40, 60);
+      const factorMax = gradeFactor(grade, 9, 9, 30, 60, 80);
       const groups = randomInt(2, factorMax);
       const perGroup = randomInt(2, factorMax);
       const answer = groups * perGroup;
@@ -527,13 +574,13 @@ export const MULTIPLICATION_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 2,
-    maxGrade: 6,
+    maxGrade: 4,
     category: 'word-story',
   },
   {
     generateProblem: (grade) => {
       const item = getRandomItem(true);
-      const factorMax = gradeFactor(grade, 9, 20, 40, 60);
+      const factorMax = gradeFactor(grade, 9, 9, 30, 60, 80);
       const groups = randomInt(2, factorMax);
       const perGroup = randomInt(2, factorMax);
       const answer = groups * perGroup;
@@ -545,13 +592,13 @@ export const MULTIPLICATION_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 2,
-    maxGrade: 6,
+    maxGrade: 4,
     category: 'word-story',
   },
   {
     generateProblem: (grade) => {
       const item = getRandomItem(true);
-      const factorMax = gradeFactor(grade, 9, 20, 40, 60);
+      const factorMax = gradeFactor(grade, 9, 9, 30, 60, 80);
       const rows = randomInt(2, factorMax);
       const cols = randomInt(2, factorMax);
       const answer = rows * cols;
@@ -563,7 +610,7 @@ export const MULTIPLICATION_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 2,
-    maxGrade: 6,
+    maxGrade: 4,
     category: 'word-story',
   },
   {
@@ -697,8 +744,8 @@ export const DIVISION_STORIES: WordStoryTemplate[] = [
   {
     generateProblem: (grade) => {
       const item = getRandomItem(true);
-      const divisorMax = gradeFactor(grade, 9, 12, 25, 40);
-      const quotientMax = gradeFactor(grade, 9, 25, 80, 200);
+      const divisorMax = gradeFactor(grade, 9, 9, 15, 30, 50);
+      const quotientMax = gradeFactor(grade, 9, 80, 120, 250, 400);
       const groups = randomInt(2, divisorMax);
       const perGroup = randomInt(2, quotientMax);
       const total = groups * perGroup;
@@ -711,14 +758,14 @@ export const DIVISION_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 3,
-    maxGrade: 6,
+    maxGrade: 5,
     category: 'word-story',
   },
   {
     generateProblem: (grade) => {
       const item = getRandomItem(true);
-      const divisorMax = gradeFactor(grade, 9, 12, 25, 40);
-      const quotientMax = gradeFactor(grade, 9, 25, 80, 200);
+      const divisorMax = gradeFactor(grade, 9, 9, 15, 30, 50);
+      const quotientMax = gradeFactor(grade, 9, 80, 120, 250, 400);
       const perBox = randomInt(2, divisorMax);
       const numBoxes = randomInt(2, quotientMax);
       const total = perBox * numBoxes;
@@ -731,14 +778,14 @@ export const DIVISION_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 3,
-    maxGrade: 6,
+    maxGrade: 5,
     category: 'word-story',
   },
   {
     generateProblem: (grade) => {
       const item = getRandomItem(true);
-      const divisorMax = gradeFactor(grade, 9, 12, 25, 40);
-      const quotientMax = gradeFactor(grade, 9, 25, 80, 200);
+      const divisorMax = gradeFactor(grade, 9, 9, 15, 30, 50);
+      const quotientMax = gradeFactor(grade, 9, 80, 120, 250, 400);
       const perRow = randomInt(2, quotientMax);
       const numRows = randomInt(2, divisorMax);
       const total = perRow * numRows;
@@ -751,7 +798,7 @@ export const DIVISION_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 3,
-    maxGrade: 6,
+    maxGrade: 5,
     category: 'word-story',
   },
   {
@@ -834,8 +881,8 @@ export const DIVISION_STORIES: WordStoryTemplate[] = [
   {
     generateProblem: (grade) => {
       const item = getRandomItem(true);
-      const divisorMax = gradeFactor(grade, 9, 12, 25, 40);
-      const quotientMax = gradeFactor(grade, 9, 25, 80, 200);
+      const divisorMax = gradeFactor(grade, 9, 9, 15, 30, 50);
+      const quotientMax = gradeFactor(grade, 9, 80, 120, 250, 400);
       const perBag = randomInt(2, quotientMax);
       const numBags = randomInt(2, divisorMax);
       const total = perBag * numBags;
@@ -1995,7 +2042,7 @@ export const PATTERN_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 2,
-    maxGrade: 6,
+    maxGrade: 4,
     category: 'word-story',
   },
   {
@@ -2028,7 +2075,7 @@ export const PATTERN_STORIES: WordStoryTemplate[] = [
       };
     },
     minGrade: 2,
-    maxGrade: 6,
+    maxGrade: 4,
     category: 'word-story',
   },
 ];
@@ -2792,6 +2839,646 @@ export const ADVANCED_STORIES: WordStoryTemplate[] = [
 ];
 
 /**
+ * Grade 3-4: 2-3 digit × 1-digit multiplication (curriculum: G3 introduces
+ * "2桁×1桁" / "3桁×1桁" hissan-style multiplication, beyond the 9×9 table).
+ */
+export const GRADE3_DIGIT_MULTIPLICATION_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const itemObj = getRandomItemPair();
+      const twoDigit = gradeRandomInt(grade, [{ upTo: 3, min: 12, max: 99 }], {
+        upTo: 6,
+        min: 100,
+        max: 400,
+      });
+      const oneDigit = randomInt(2, 9);
+      const answer = twoDigit * oneDigit;
+
+      return {
+        text: `A pack has ${twoDigit} ${itemObj.plural}. There are ${oneDigit} packs. How many ${itemObj.plural} in total?`,
+        answer,
+        operation: 'multiplication' as Operation,
+      };
+    },
+    minGrade: 3,
+    maxGrade: 4,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const pronouns = getPronouns(name);
+      const perDay = gradeRandomInt(grade, [{ upTo: 3, min: 15, max: 95 }], {
+        upTo: 6,
+        min: 80,
+        max: 350,
+      });
+      const days = randomInt(3, 9);
+      const answer = perDay * days;
+
+      return {
+        text: `${name} saves ${perDay} yen every day. How much money does ${pronouns.lowerSubject} save in ${days} days?`,
+        answer,
+        operation: 'multiplication' as Operation,
+      };
+    },
+    minGrade: 3,
+    maxGrade: 4,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 3-4: Division with remainder (curriculum: G3 "あまりのある割り算").
+ * Answer is a string in the form "q R r" (or just "q" if r === 0).
+ */
+export const DIVISION_REMAINDER_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const itemObj = getRandomItemPair();
+      const pronouns = getPronouns(name);
+      const d = randomInt(3, 9);
+      const q = gradeRandomInt(grade, [{ upTo: 3, min: 4, max: 30 }], {
+        upTo: 6,
+        min: 8,
+        max: 80,
+      });
+      const r = randomInt(1, d - 1);
+      const dividend = d * q + r;
+      const answer = formatRemainder(q, r);
+
+      return {
+        text: `${name} has ${dividend} ${itemObj.plural}. ${pronouns.subject} packs them into bags of ${d}. How many bags are full, and how many ${itemObj.plural} are left over?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 3,
+    maxGrade: 4,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const d = randomInt(3, 9);
+      const q = gradeRandomInt(grade, [{ upTo: 3, min: 4, max: 20 }], {
+        upTo: 6,
+        min: 8,
+        max: 60,
+      });
+      const r = randomInt(1, d - 1);
+      const dividend = d * q + r;
+      const answer = formatRemainder(q, r);
+
+      return {
+        text: `${dividend} cookies are shared equally among ${d} children. How many cookies does each child get, and how many are left over?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 3,
+    maxGrade: 4,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 3-6: Unit-fraction problems (curriculum: G3 introduces 1/n as a way
+ * to split a whole into equal parts). Answer is a count (number).
+ */
+export const UNIT_FRACTION_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const denom = randomInt(2, 6);
+      const k = gradeRandomInt(grade, [{ upTo: 3, min: 3, max: 12 }], {
+        upTo: 6,
+        min: 10,
+        max: 40,
+      });
+      const total = denom * k;
+      const answer = k;
+
+      return {
+        text: `A ribbon is ${total} cm long. ${name} cuts it into ${denom} equal pieces. How long is one piece, in cm?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 3,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const itemObj = getRandomItemPair();
+      const pronouns = getPronouns(name);
+      const denom = randomInt(2, 5);
+      const k = gradeRandomInt(grade, [{ upTo: 3, min: 3, max: 12 }], {
+        upTo: 6,
+        min: 10,
+        max: 40,
+      });
+      const total = denom * k;
+      const answer = k;
+
+      return {
+        text: `${name} has ${total} ${itemObj.plural}. ${pronouns.subject} gives away 1/${denom} of them. How many ${itemObj.plural} did ${pronouns.lowerSubject} give away?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 3,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 3-5: Tenths decimal addition / subtraction (curriculum: G3 introduces
+ * 小数 to the 0.1 place; G4-5 extend it). Answer is a formatted decimal string.
+ */
+export const DECIMAL_ADD_SUB_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const pronouns = getPronouns(name);
+      const a10 = gradeRandomInt(grade, [{ upTo: 3, min: 3, max: 90 }], {
+        upTo: 5,
+        min: 10,
+        max: 400,
+      });
+      const b10 = gradeRandomInt(grade, [{ upTo: 3, min: 3, max: 90 }], {
+        upTo: 5,
+        min: 10,
+        max: 400,
+      });
+      const a = formatDecimal(a10 / 10, 1);
+      const b = formatDecimal(b10 / 10, 1);
+      const answer = formatDecimal((a10 + b10) / 10, 1);
+
+      return {
+        text: `${name} drinks ${a} L of juice in the morning and ${b} L in the afternoon. How many liters does ${pronouns.lowerSubject} drink in total?`,
+        answer,
+        operation: 'addition' as Operation,
+      };
+    },
+    minGrade: 3,
+    maxGrade: 5,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const pronouns = getPronouns(name);
+      const total10 = gradeRandomInt(grade, [{ upTo: 3, min: 20, max: 95 }], {
+        upTo: 5,
+        min: 50,
+        max: 500,
+      });
+      const used10 = randomInt(5, total10 - 3);
+      const totalStr = formatDecimal(total10 / 10, 1);
+      const usedStr = formatDecimal(used10 / 10, 1);
+      const answer = formatDecimal((total10 - used10) / 10, 1);
+
+      return {
+        text: `${name} has ${totalStr} m of string. ${pronouns.subject} uses ${usedStr} m. How many meters of string are left?`,
+        answer,
+        operation: 'subtraction' as Operation,
+      };
+    },
+    minGrade: 3,
+    maxGrade: 5,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 4-6: Same-denominator fraction addition / subtraction (curriculum:
+ * G4 "同分母の分数の加減"). G4 keeps results unreduced; G5+ reduces.
+ */
+export const FRACTION_SAME_DENOM_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const name1 = getRandomName();
+      const name2 = getDifferentName(name1);
+      const denom = randomInt(3, 8);
+      const a = randomInt(1, denom - 2);
+      const b = randomInt(1, denom - a - 1);
+      const sum = a + b;
+      const { n, d } =
+        grade >= 5 ? reduceFraction(sum, denom) : { n: sum, d: denom };
+      const answer = formatFraction(n, d);
+
+      return {
+        text: `${name1} ate ${a}/${denom} of a pizza and ${name2} ate ${b}/${denom} of the same pizza. How much pizza did they eat altogether?`,
+        answer,
+        operation: 'addition' as Operation,
+      };
+    },
+    minGrade: 4,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const pronouns = getPronouns(name);
+      const denom = randomInt(3, 8);
+      const a = randomInt(2, denom - 1);
+      const b = randomInt(1, a - 1);
+      const diff = a - b;
+      const { n, d } =
+        grade >= 5 ? reduceFraction(diff, denom) : { n: diff, d: denom };
+      const answer = formatFraction(n, d);
+
+      return {
+        text: `${name} had ${a}/${denom} of a chocolate bar. ${pronouns.subject} ate ${b}/${denom} of the bar. How much chocolate is left?`,
+        answer,
+        operation: 'subtraction' as Operation,
+      };
+    },
+    minGrade: 4,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 4-6: Decimal × integer and decimal ÷ integer
+ * (curriculum: G4 "小数 × ÷ 整数"). Answers are decimal strings.
+ */
+export const DECIMAL_INT_OP_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const dec10 = gradeRandomInt(grade, [{ upTo: 4, min: 2, max: 90 }], {
+        upTo: 6,
+        min: 10,
+        max: 250,
+      });
+      const k = gradeRandomInt(grade, [{ upTo: 4, min: 2, max: 9 }], {
+        upTo: 6,
+        min: 3,
+        max: 25,
+      });
+      const decStr = formatDecimal(dec10 / 10, 1);
+      const answer = formatDecimal((dec10 * k) / 10, 1);
+
+      return {
+        text: `One bottle holds ${decStr} L of water. There are ${k} bottles. How many liters of water are there in total?`,
+        answer,
+        operation: 'multiplication' as Operation,
+      };
+    },
+    minGrade: 4,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const divisor = gradeRandomInt(grade, [{ upTo: 4, min: 2, max: 9 }], {
+        upTo: 6,
+        min: 3,
+        max: 25,
+      });
+      const quotient10 = gradeRandomInt(grade, [{ upTo: 4, min: 2, max: 90 }], {
+        upTo: 6,
+        min: 10,
+        max: 250,
+      });
+      const dividend10 = quotient10 * divisor;
+      const dividendStr = formatDecimal(dividend10 / 10, 1);
+      const answer = formatDecimal(quotient10 / 10, 1);
+
+      return {
+        text: `${dividendStr} L of juice is poured equally into ${divisor} cups. How many liters are in each cup?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 4,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 5-6: Decimal × decimal and decimal ÷ decimal
+ * (curriculum: G5 "小数 × 小数 / 小数 ÷ 小数"). Answers are decimal strings.
+ */
+export const DECIMAL_DECIMAL_OP_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const a10 = gradeRandomInt(grade, [{ upTo: 5, min: 12, max: 50 }], {
+        upTo: 6,
+        min: 15,
+        max: 90,
+      });
+      const b10 = gradeRandomInt(grade, [{ upTo: 5, min: 8, max: 40 }], {
+        upTo: 6,
+        min: 10,
+        max: 70,
+      });
+      const aStr = formatDecimal(a10 / 10, 1);
+      const bStr = formatDecimal(b10 / 10, 1);
+      const answer = formatDecimal((a10 * b10) / 100, 2);
+
+      return {
+        text: `A rectangular tile is ${aStr} m long and ${bStr} m wide. What is its area in square meters?`,
+        answer,
+        operation: 'multiplication' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const q10 = gradeRandomInt(grade, [{ upTo: 5, min: 12, max: 50 }], {
+        upTo: 6,
+        min: 15,
+        max: 90,
+      });
+      const b10 = gradeRandomInt(grade, [{ upTo: 5, min: 12, max: 40 }], {
+        upTo: 6,
+        min: 15,
+        max: 70,
+      });
+      const dividend100 = q10 * b10;
+      const dividendStr = formatDecimal(dividend100 / 100, 2);
+      const bStr = formatDecimal(b10 / 10, 1);
+      const answer = formatDecimal(q10 / 10, 1);
+
+      return {
+        text: `A garden has area ${dividendStr} square meters. It is ${bStr} m wide. How many meters long is it?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 5-6: Different-denominator fraction addition / subtraction
+ * (curriculum: G5 "異分母の分数の加減"). Answers are reduced fractions.
+ */
+export const FRACTION_DIFF_DENOM_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: () => {
+      const denomPairs: Array<[number, number]> = [
+        [2, 3],
+        [2, 5],
+        [3, 4],
+        [3, 6],
+        [4, 6],
+        [3, 9],
+        [4, 8],
+      ];
+      const [d1, d2] = denomPairs[randomInt(0, denomPairs.length - 1)];
+      const a = randomInt(1, d1 - 1);
+      const b = randomInt(1, d2 - 1);
+      const lcm = (d1 * d2) / gcd(d1, d2);
+      const sumNum = a * (lcm / d1) + b * (lcm / d2);
+      const { n, d } = reduceFraction(sumNum, lcm);
+      const answer = formatFraction(n, d);
+      const name = getRandomName();
+
+      return {
+        text: `${name} painted ${a}/${d1} of a wall in the morning and ${b}/${d2} of the same wall in the afternoon. What fraction of the wall is painted now?`,
+        answer,
+        operation: 'addition' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: () => {
+      const denomPairs: Array<[number, number]> = [
+        [2, 3],
+        [3, 4],
+        [3, 6],
+        [4, 6],
+        [4, 8],
+        [3, 9],
+      ];
+      const [d1, d2] = denomPairs[randomInt(0, denomPairs.length - 1)];
+      const lcm = (d1 * d2) / gcd(d1, d2);
+      // Pick numerators so first fraction strictly exceeds the second.
+      let attempts = 0;
+      let a = 1;
+      let b = 1;
+      while (attempts < 20) {
+        a = randomInt(2, d1 - 1);
+        b = randomInt(1, d2 - 1);
+        if (a * (lcm / d1) > b * (lcm / d2)) break;
+        attempts++;
+      }
+      const diffNum = a * (lcm / d1) - b * (lcm / d2);
+      const { n, d } = reduceFraction(diffNum, lcm);
+      const answer = formatFraction(n, d);
+      const name = getRandomName();
+
+      return {
+        text: `${name} had ${a}/${d1} of a cake. ${getSubjectPronoun(name)} ate ${b}/${d2} of the same cake. How much cake is left?`,
+        answer,
+        operation: 'subtraction' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 5-6: Speed / distance / time problems (curriculum: G5 "速さ").
+ * Three variants: find distance, find time, find speed.
+ * Answers are numbers (selected so divisions terminate exactly).
+ */
+export const SPEED_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const speed = gradeRandomInt(grade, [{ upTo: 5, min: 20, max: 70 }], {
+        upTo: 6,
+        min: 30,
+        max: 110,
+      });
+      const time = randomInt(2, 6);
+      const answer = speed * time;
+
+      return {
+        text: `A car travels at ${speed} km/h for ${time} hours. How far does it go, in km?`,
+        answer,
+        operation: 'multiplication' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const pronouns = getPronouns(name);
+      const speed = gradeRandomInt(grade, [{ upTo: 5, min: 40, max: 90 }], {
+        upTo: 6,
+        min: 50,
+        max: 120,
+      });
+      const minutes = randomInt(3, 12);
+      const distance = speed * minutes;
+      const answer = minutes;
+
+      return {
+        text: `${name} walks ${distance} m to school at ${speed} m per minute. How many minutes does ${pronouns.lowerSubject} take?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const speed = gradeRandomInt(grade, [{ upTo: 5, min: 30, max: 80 }], {
+        upTo: 6,
+        min: 40,
+        max: 120,
+      });
+      const time = randomInt(2, 6);
+      const distance = speed * time;
+      const answer = speed;
+
+      return {
+        text: `A train covers ${distance} km in ${time} hours. What is its speed, in km/h?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 5-6: Percent / ratio "of-a-quantity" problems
+ * (curriculum: G5 "百分率 / 割合").
+ */
+export const PERCENT_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: (grade) => {
+      const name = getRandomName();
+      const itemObj = getRandomItemPair();
+      const base = gradeRandomInt(grade, [{ upTo: 5, min: 50, max: 500 }], {
+        upTo: 6,
+        min: 100,
+        max: 1500,
+      });
+      const baseRounded = Math.round(base / 10) * 10;
+      const percents = [10, 20, 25, 50, 75, 80];
+      const p = percents[randomInt(0, percents.length - 1)];
+      // Ensure base * p is divisible by 100 for a clean integer answer.
+      const finalBase =
+        (baseRounded * p) % 100 === 0
+          ? baseRounded
+          : Math.round(baseRounded / 100) * 100 || 100;
+      const answer = (finalBase * p) / 100;
+
+      return {
+        text: `${name} has ${finalBase} ${itemObj.plural}. ${p}% of them are red. How many red ${itemObj.plural} are there?`,
+        answer,
+        operation: 'multiplication' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: (grade) => {
+      const baseHundreds = gradeRandomInt(
+        grade,
+        [{ upTo: 5, min: 1, max: 5 }],
+        { upTo: 6, min: 2, max: 12 }
+      );
+      const base = baseHundreds * 100;
+      const percents = [10, 20, 25, 40, 60, 75];
+      const p = percents[randomInt(0, percents.length - 1)];
+      const present = (base * p) / 100;
+      const answer = base - present;
+
+      return {
+        text: `A class has ${base} students. ${p}% of them are present today. How many students are absent?`,
+        answer,
+        operation: 'subtraction' as Operation,
+      };
+    },
+    minGrade: 5,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+];
+
+/**
+ * Grade 6: Fraction × fraction and fraction ÷ fraction
+ * (curriculum: G6 "分数 × 分数 / 分数 ÷ 分数"). Answers are reduced fractions.
+ */
+export const FRACTION_MUL_DIV_STORIES: WordStoryTemplate[] = [
+  {
+    generateProblem: () => {
+      const name = getRandomName();
+      const pronouns = getPronouns(name);
+      const b = randomInt(2, 6);
+      const a = randomInt(1, b - 1);
+      const d = randomInt(2, 6);
+      const c = randomInt(1, d - 1);
+      const { n: rn, d: rd } = reduceFraction(a * c, b * d);
+      const answer = formatFraction(rn, rd);
+
+      return {
+        text: `A recipe uses ${a}/${b} cup of flour. ${name} wants to make ${c}/${d} of the recipe. How much flour does ${pronouns.lowerSubject} need, in cups?`,
+        answer,
+        operation: 'multiplication' as Operation,
+      };
+    },
+    minGrade: 6,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+  {
+    generateProblem: () => {
+      const name = getRandomName();
+      const pronouns = getPronouns(name);
+      const b = randomInt(2, 6);
+      const a = randomInt(1, b - 1);
+      const d = randomInt(2, 6);
+      const c = randomInt(1, d - 1);
+      // Dividing a/b by c/d = (a*d) / (b*c).
+      const { n: rn, d: rd } = reduceFraction(a * d, b * c);
+      const answer = formatFraction(rn, rd);
+
+      return {
+        text: `${name} has ${a}/${b} of a meter of ribbon. ${pronouns.subject} cuts it into pieces that are ${c}/${d} of a meter each. How many pieces does ${pronouns.lowerSubject} get?`,
+        answer,
+        operation: 'division' as Operation,
+      };
+    },
+    minGrade: 6,
+    maxGrade: 6,
+    category: 'word-story',
+  },
+];
+
+/**
  * Get appropriate story templates for a grade level
  */
 export function getStoriesForGrade(grade: number): WordStoryTemplate[] {
@@ -2804,7 +3491,18 @@ export function getStoriesForGrade(grade: number): WordStoryTemplate[] {
     ...SECOND_GRADE_CONTEXT_STORIES,
     ...MULTI_STEP_STORIES,
     ...MULTIPLICATION_STORIES,
+    ...GRADE3_DIGIT_MULTIPLICATION_STORIES,
     ...DIVISION_STORIES,
+    ...DIVISION_REMAINDER_STORIES,
+    ...UNIT_FRACTION_STORIES,
+    ...DECIMAL_ADD_SUB_STORIES,
+    ...FRACTION_SAME_DENOM_STORIES,
+    ...DECIMAL_INT_OP_STORIES,
+    ...DECIMAL_DECIMAL_OP_STORIES,
+    ...FRACTION_DIFF_DENOM_STORIES,
+    ...SPEED_STORIES,
+    ...PERCENT_STORIES,
+    ...FRACTION_MUL_DIV_STORIES,
     ...COMPARISON_STORIES,
     ...TIME_STORIES,
     ...MONEY_STORIES,

--- a/src/lib/generators/templates/en-word-story.ts
+++ b/src/lib/generators/templates/en-word-story.ts
@@ -3240,9 +3240,23 @@ export const FRACTION_DIFF_DENOM_STORIES: WordStoryTemplate[] = [
         [4, 8],
       ];
       const [d1, d2] = denomPairs[randomInt(0, denomPairs.length - 1)];
-      const a = randomInt(1, d1 - 1);
-      const b = randomInt(1, d2 - 1);
       const lcm = (d1 * d2) / gcd(d1, d2);
+      // Pick numerators so the sum stays within one whole wall
+      // (a/d1 + b/d2 <= 1). 1/d1 + 1/d2 is always <= 1 for d1, d2 >= 2 with
+      // (d1, d2) != (2, 2), so the (1, 1) default is always safe here.
+      let a = 1;
+      let b = 1;
+      let attempts = 0;
+      while (attempts < 20) {
+        const testA = randomInt(1, d1 - 1);
+        const testB = randomInt(1, d2 - 1);
+        if (testA * (lcm / d1) + testB * (lcm / d2) <= lcm) {
+          a = testA;
+          b = testB;
+          break;
+        }
+        attempts++;
+      }
       const sumNum = a * (lcm / d1) + b * (lcm / d2);
       const { n, d } = reduceFraction(sumNum, lcm);
       const answer = formatFraction(n, d);
@@ -3271,13 +3285,19 @@ export const FRACTION_DIFF_DENOM_STORIES: WordStoryTemplate[] = [
       const [d1, d2] = denomPairs[randomInt(0, denomPairs.length - 1)];
       const lcm = (d1 * d2) / gcd(d1, d2);
       // Pick numerators so first fraction strictly exceeds the second.
-      let attempts = 0;
-      let a = 1;
+      // Safe default: a = d1 - 1, b = 1 guarantees a/d1 >= 1/2 and
+      // b/d2 <= 1/3 for the denomPairs above, so a/d1 > b/d2 always holds.
+      let a = d1 - 1;
       let b = 1;
+      let attempts = 0;
       while (attempts < 20) {
-        a = randomInt(2, d1 - 1);
-        b = randomInt(1, d2 - 1);
-        if (a * (lcm / d1) > b * (lcm / d2)) break;
+        const testA = randomInt(d1 === 2 ? 1 : 2, d1 - 1);
+        const testB = randomInt(1, d2 - 1);
+        if (testA * (lcm / d1) > testB * (lcm / d2)) {
+          a = testA;
+          b = testB;
+          break;
+        }
         attempts++;
       }
       const diffNum = a * (lcm / d1) - b * (lcm / d2);

--- a/src/lib/generators/word-problem-en-integration.test.ts
+++ b/src/lib/generators/word-problem-en-integration.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { generateGradeEnWordProblems } from './word-problem-en';
-import { getPrintTemplate, detectPrimaryProblemType } from '../../config/print-templates';
+import {
+  getPrintTemplate,
+  detectPrimaryProblemType,
+} from '../../config/print-templates';
 import type { WordProblemEn } from '../../types';
 
 /**
@@ -114,7 +117,10 @@ describe('Word Problem EN Integration', () => {
 
     it('should generate grade 6 problems with appropriate settings', () => {
       const template = getPrintTemplate('word-en');
-      const problems = generateGradeEnWordProblems(6, template.recommendedCounts[3]);
+      const problems = generateGradeEnWordProblems(
+        6,
+        template.recommendedCounts[3]
+      );
 
       expect(problems).toHaveLength(template.recommendedCounts[3]);
       expect(template.recommendedCounts[3]).toBe(18);
@@ -178,19 +184,23 @@ describe('Word Problem EN Integration', () => {
     it('should not generate number sequence problems for grade 3+', () => {
       // Test grade 3
       const grade3Problems = generateGradeEnWordProblems(3, 30);
-      const hasSequenceProblem = grade3Problems.some((p) =>
-        p.problemText.includes('comes just before') ||
-        p.problemText.includes('comes just after') ||
-        p.problemText.includes('is between') ||
-        p.problemText.includes('Count') && (p.problemText.includes('forward') || p.problemText.includes('backward'))
+      const hasSequenceProblem = grade3Problems.some(
+        (p) =>
+          p.problemText.includes('comes just before') ||
+          p.problemText.includes('comes just after') ||
+          p.problemText.includes('is between') ||
+          (p.problemText.includes('Count') &&
+            (p.problemText.includes('forward') ||
+              p.problemText.includes('backward')))
       );
       expect(hasSequenceProblem).toBe(false);
 
       // Test grade 5
       const grade5Problems = generateGradeEnWordProblems(5, 30);
-      const hasSequenceProblemGrade5 = grade5Problems.some((p) =>
-        p.problemText.includes('comes just before') ||
-        p.problemText.includes('comes just after')
+      const hasSequenceProblemGrade5 = grade5Problems.some(
+        (p) =>
+          p.problemText.includes('comes just before') ||
+          p.problemText.includes('comes just after')
       );
       expect(hasSequenceProblemGrade5).toBe(false);
     });
@@ -198,22 +208,28 @@ describe('Word Problem EN Integration', () => {
     it('should include number sequence problems for grades 1-2', () => {
       // Test grade 1
       const grade1Problems = generateGradeEnWordProblems(1, 20);
-      const hasSequenceProblemGrade1 = grade1Problems.some((p) =>
-        p.problemText.includes('comes just before') ||
-        p.problemText.includes('comes just after') ||
-        p.problemText.includes('is between') ||
-        (p.problemText.includes('Count') && (p.problemText.includes('forward') || p.problemText.includes('backward')))
+      const hasSequenceProblemGrade1 = grade1Problems.some(
+        (p) =>
+          p.problemText.includes('comes just before') ||
+          p.problemText.includes('comes just after') ||
+          p.problemText.includes('is between') ||
+          (p.problemText.includes('Count') &&
+            (p.problemText.includes('forward') ||
+              p.problemText.includes('backward')))
       );
       // Should be possible to generate sequence problems for grade 1
       expect(typeof hasSequenceProblemGrade1).toBe('boolean');
 
       // Test grade 2
       const grade2Problems = generateGradeEnWordProblems(2, 20);
-      const hasSequenceProblemGrade2 = grade2Problems.some((p) =>
-        p.problemText.includes('comes just before') ||
-        p.problemText.includes('comes just after') ||
-        p.problemText.includes('is between') ||
-        (p.problemText.includes('Count') && (p.problemText.includes('forward') || p.problemText.includes('backward')))
+      const hasSequenceProblemGrade2 = grade2Problems.some(
+        (p) =>
+          p.problemText.includes('comes just before') ||
+          p.problemText.includes('comes just after') ||
+          p.problemText.includes('is between') ||
+          (p.problemText.includes('Count') &&
+            (p.problemText.includes('forward') ||
+              p.problemText.includes('backward')))
       );
       // Should be possible to generate sequence problems for grade 2
       expect(typeof hasSequenceProblemGrade2).toBe('boolean');
@@ -253,8 +269,12 @@ describe('Word Problem EN Integration', () => {
 
       problems.forEach((problem) => {
         expect(problem.answer).toBeDefined();
-        expect(typeof problem.answer).toBe('number');
-        expect(problem.answer).toBeGreaterThanOrEqual(0);
+        expect(['number', 'string']).toContain(typeof problem.answer);
+        if (typeof problem.answer === 'number') {
+          expect(problem.answer).toBeGreaterThanOrEqual(0);
+        } else {
+          expect(problem.answer.length).toBeGreaterThan(0);
+        }
       });
     });
 

--- a/src/lib/generators/word-problem-en.test.ts
+++ b/src/lib/generators/word-problem-en.test.ts
@@ -100,15 +100,14 @@ describe('English Word Problem Generator', () => {
       const grade5Problems = generateEnWordStory(5, 80);
       const grade6Problems = generateEnWordStory(6, 100);
 
-      const grade4Max = Math.max(
-        ...grade4Problems.map((problem) => problem.answer as number)
-      );
-      const grade5Max = Math.max(
-        ...grade5Problems.map((problem) => problem.answer as number)
-      );
-      const grade6Max = Math.max(
-        ...grade6Problems.map((problem) => problem.answer as number)
-      );
+      const numericAnswers = (problems: WordProblemEn[]): number[] =>
+        problems
+          .map((p) => p.answer)
+          .filter((a): a is number => typeof a === 'number');
+
+      const grade4Max = Math.max(...numericAnswers(grade4Problems));
+      const grade5Max = Math.max(...numericAnswers(grade5Problems));
+      const grade6Max = Math.max(...numericAnswers(grade6Problems));
 
       // Grade 4 should regularly reach 3-digit territory.
       expect(grade4Max).toBeGreaterThanOrEqual(250);
@@ -221,7 +220,10 @@ describe('English Word Problem Generator', () => {
   describe('Upper-elementary difficulty (grade 4+)', () => {
     it('grade 4 should produce some answers at or above 200', () => {
       const problems = generateEnWordStory(4, 80);
-      const max = Math.max(...problems.map((p) => p.answer as number));
+      const numerics = problems
+        .map((p) => p.answer)
+        .filter((a): a is number => typeof a === 'number');
+      const max = Math.max(...numerics);
       expect(max).toBeGreaterThanOrEqual(200);
     });
 
@@ -394,12 +396,19 @@ describe('English Word Problem Generator', () => {
       problems.forEach((problem) => {
         const answer = problem.answer;
         expect(answer).toBeDefined();
-        expect(typeof answer).toBe('number');
-        // Some comparison problems may have negative results (e.g., "fewer than")
-        // but the absolute value should be reasonable
-        expect(Number.isFinite(answer as number)).toBe(true);
-        expect(Math.abs(answer as number)).toBeGreaterThanOrEqual(0);
-        expect(Math.abs(answer as number)).toBeLessThan(200000);
+        expect(['number', 'string']).toContain(typeof answer);
+        if (typeof answer === 'number') {
+          // Some comparison problems may have negative results (e.g., "fewer than")
+          // but the absolute value should be reasonable
+          expect(Number.isFinite(answer)).toBe(true);
+          expect(Math.abs(answer)).toBeGreaterThanOrEqual(0);
+          expect(Math.abs(answer)).toBeLessThan(200000);
+        } else {
+          // String answers should be non-empty and match a fraction/decimal/
+          // remainder shape (no garbled output).
+          expect(answer.length).toBeGreaterThan(0);
+          expect(answer).toMatch(/^[\d./ R-]+$/);
+        }
       });
     });
 
@@ -485,6 +494,129 @@ describe('English Word Problem Generator', () => {
         // Grade 1 should only have addition and subtraction
         expect(['addition', 'subtraction']).toContain(problem.operation);
       });
+    });
+  });
+
+  describe('Curriculum coverage', () => {
+    // Sample sizes are large enough to make statistical coverage robust.
+    const SAMPLE = 250;
+
+    it('grade 3 should sometimes produce multiplication answers ≥ 100 (2-3桁×1桁)', () => {
+      const problems = generateGradeEnWordProblems(3, SAMPLE);
+      const hit = problems.some(
+        (p) =>
+          p.operation === 'multiplication' &&
+          typeof p.answer === 'number' &&
+          p.answer >= 100
+      );
+      expect(hit).toBe(true);
+    });
+
+    it('grade 3 should sometimes produce remainder-style "q R r" answers', () => {
+      const problems = generateGradeEnWordProblems(3, SAMPLE);
+      const hit = problems.some(
+        (p) => typeof p.answer === 'string' && / R \d+/.test(p.answer)
+      );
+      expect(hit).toBe(true);
+    });
+
+    it('grade 3 should sometimes produce unit-fraction (1/n) problems', () => {
+      const problems = generateGradeEnWordProblems(3, SAMPLE);
+      const hit = problems.some((p) =>
+        /\b1\/\d+\b|equal pieces/.test(p.problemText)
+      );
+      expect(hit).toBe(true);
+    });
+
+    it('grade 3 should sometimes produce tenths decimal problems', () => {
+      const problems = generateGradeEnWordProblems(3, SAMPLE);
+      const hit = problems.some(
+        (p) => typeof p.answer === 'string' && /^\d+\.\d+$/.test(p.answer)
+      );
+      expect(hit).toBe(true);
+    });
+
+    it('grade 4 should sometimes produce same-denominator fraction answers', () => {
+      const problems = generateGradeEnWordProblems(4, SAMPLE);
+      const hit = problems.some(
+        (p) => typeof p.answer === 'string' && /^\d+\/\d+$/.test(p.answer)
+      );
+      expect(hit).toBe(true);
+    });
+
+    it('grade 4 should sometimes produce decimal × integer / decimal ÷ integer', () => {
+      const problems = generateGradeEnWordProblems(4, SAMPLE);
+      const hit = problems.some(
+        (p) => typeof p.answer === 'string' && /^\d+\.\d+$/.test(p.answer)
+      );
+      expect(hit).toBe(true);
+    });
+
+    it('grade 5 should sometimes produce decimal × decimal / decimal ÷ decimal', () => {
+      const problems = generateGradeEnWordProblems(5, SAMPLE);
+      const hit = problems.some(
+        (p) =>
+          typeof p.answer === 'string' &&
+          /^\d+\.\d{1,2}$/.test(p.answer) &&
+          /square meters|m wide|garden has area/.test(p.problemText)
+      );
+      expect(hit).toBe(true);
+    });
+
+    it('grade 5 should sometimes produce different-denominator fraction answers', () => {
+      const problems = generateGradeEnWordProblems(5, SAMPLE);
+      const hit = problems.some((p) => {
+        if (typeof p.answer !== 'string' || !/^\d+\/\d+$/.test(p.answer)) {
+          return false;
+        }
+        // Look for two distinct denominators in the problem text.
+        const denoms = (p.problemText.match(/\d+\/(\d+)/g) ?? []).map((m) =>
+          Number(m.split('/')[1])
+        );
+        return new Set(denoms).size >= 2;
+      });
+      expect(hit).toBe(true);
+    });
+
+    it('grade 5 should include speed / distance / time problems', () => {
+      const problems = generateGradeEnWordProblems(5, SAMPLE);
+      const hit = problems.some((p) =>
+        /km\/h|km in|m per minute/.test(p.problemText)
+      );
+      expect(hit).toBe(true);
+    });
+
+    it('grade 5 should include percent problems', () => {
+      const problems = generateGradeEnWordProblems(5, SAMPLE);
+      const hit = problems.some((p) => /\b\d+%/.test(p.problemText));
+      expect(hit).toBe(true);
+    });
+
+    it('grade 6 should sometimes produce fraction × fraction or fraction ÷ fraction', () => {
+      const problems = generateGradeEnWordProblems(6, SAMPLE);
+      const hit = problems.some((p) => {
+        const fractions = p.problemText.match(/\d+\/\d+/g) ?? [];
+        return fractions.length >= 2;
+      });
+      expect(hit).toBe(true);
+    });
+
+    it('grade 6 should NOT include simple 1-digit × 1-digit multiplication templates', () => {
+      // MULTIPLICATION_STORIES[0-2] (basic "boxes/groups/rows") are now capped at G4.
+      const problems = generateGradeEnWordProblems(6, SAMPLE);
+      const simpleBoxesPattern =
+        /^There are \d+ boxes\. Each box has \d+ \w+\. How many \w+ are there in total\?$/;
+      const simpleGroupsPattern =
+        /^There are \d+ groups of \d+ \w+\. How many \w+ are there altogether\?$/;
+      const simpleRowsPattern =
+        /^\w+ are arranged in \d+ rows with \d+ in each row\. How many \w+ are there in total\?$/;
+      const hitsBasicMul = problems.some(
+        (p) =>
+          simpleBoxesPattern.test(p.problemText) ||
+          simpleGroupsPattern.test(p.problemText) ||
+          simpleRowsPattern.test(p.problemText)
+      );
+      expect(hitsBasicMul).toBe(false);
     });
   });
 });

--- a/src/lib/generators/word-problem-en.test.ts
+++ b/src/lib/generators/word-problem-en.test.ts
@@ -8,6 +8,7 @@ import {
   MONEY_STORIES,
   MIXED_OPERATION_STORIES,
   TIME_STORIES,
+  FRACTION_DIFF_DENOM_STORIES,
 } from './templates/en-word-story';
 import type { WordProblemEn } from '../../types';
 
@@ -617,6 +618,38 @@ describe('English Word Problem Generator', () => {
           simpleRowsPattern.test(p.problemText)
       );
       expect(hitsBasicMul).toBe(false);
+    });
+  });
+
+  describe('Different-denominator fraction story templates', () => {
+    // Regression guards for PR #72 review feedback:
+    // - Addition variant must keep painted-wall fractions ≤ 1 whole
+    // - Subtraction variant must never produce a negative cake fraction
+    const ADDITION_TEMPLATE = FRACTION_DIFF_DENOM_STORIES[0];
+    const SUBTRACTION_TEMPLATE = FRACTION_DIFF_DENOM_STORIES[1];
+
+    const parseFractionAnswer = (answer: number | string): number => {
+      if (typeof answer === 'number') return answer;
+      const [n, d] = answer.split('/').map(Number);
+      return d ? n / d : n;
+    };
+
+    it('addition story (painted wall) keeps the painted fraction ≤ 1', () => {
+      for (let i = 0; i < 500; i++) {
+        const { answer } = ADDITION_TEMPLATE.generateProblem(5);
+        const value = parseFractionAnswer(answer);
+        expect(value).toBeGreaterThan(0);
+        expect(value).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('subtraction story (eaten cake) never produces a negative fraction', () => {
+      for (let i = 0; i < 500; i++) {
+        const { answer } = SUBTRACTION_TEMPLATE.generateProblem(5);
+        const value = parseFractionAnswer(answer);
+        expect(value).toBeGreaterThan(0);
+        expect(value).toBeLessThan(1);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- English Word Problems の各学年に、その学年で実際に習う計算（2桁×1桁、分数加減、小数演算、速さ、百分率など）を確実に含めるよう改修
- 学年に対して簡単すぎる/難しすぎるテンプレートを `minGrade`/`maxGrade` で再配分
- 答えが分数・小数・あまりになるケースを `number | string` でレンダラ変更なしに表示

## 背景

`word-en` は学年帯域を持っていたが、Grade 3 は **九九（9×9）どまり**、割り算は **9÷9 まで**、**分数・小数・あまりのある割り算が一切存在しない** という、日本の小学校算数カリキュラムから大きく乖離した状態だった。Grade 4-6 も分数の加減・乗除、小数演算、速さといった中核単元が抜けていた。

| 学年 | 追加した内容 | 縮小した内容 |
|------|------|------|
| G1 | （変更なし） | — |
| G2 | （変更なし） | — |
| G3 | 2-3桁×1桁掛け算、あまりのある割り算、単位分数、小数(0.1)加減 | DIVISION 帯域を拡張 |
| G4 | 同分母分数加減、小数×÷整数 | MULTIPLICATION[0-2] を maxGrade:4 に |
| G5 | 異分母分数加減、小数×小数、小数÷小数、速さ(3変種)、百分率 | DIVISION[0-2] を maxGrade:5 に |
| G6 | 分数×分数、分数÷分数 | 単純な九九・基本割り算テンプレートを除外 |

## 主な変更点

### `src/lib/generators/templates/en-word-story.ts`
- `gradeFactor` を **6引数化**（G3独立帯）。11箇所の呼び出しを更新
- `WordStoryTemplate.answer` を **`number | string`** に拡張
- ヘルパー追加: `gcd`, `reduceFraction`, `formatFraction`, `formatDecimal`, `formatRemainder`
- 新規10カテゴリのテンプレート群を追加し `getStoriesForGrade` に登録

### `WordProblemEn.tsx` / `assertions.ts` / 型定義
- 変更なし。`answer: number | string` は既存型がサポート、レンダラは文字列をそのまま表示

### テスト
- 既存テストの `typeof === 'number'` 固定を `number | string` 対応に緩和
- `Math.max(...answers as number[])` の `NaN` 伝播を数値フィルタで防止
- 新規 `Curriculum coverage` describe で **12個の lock-in テスト**（各250サンプル）を追加し、学年ごとの必須カバレッジを統計的に担保

## 学年別サンプル（実物）

- **G3**: \"Zoe saves 91 yen every day. How much money does she save in 4 days?\"（91×4）/ \"Lucy has 2.6 m of string. She uses 1.2 m.\"
- **G4**: \"Finn had 2/5 of a chocolate bar. He ate 1/5\" / \"One bottle holds 7.8 L of water. There are 6 bottles.\"
- **G5**: \"A garden has area 4.95 square meters. It is 1.5 m wide.\" / \"A train covers 152 km in 4 hours. What is its speed, km/h?\"
- **G6**: \"Sam had 2/3 of a cake. He ate 2/4 of the same cake.\"（異分母）

## Test plan

- [x] \`npm run lint\` 成功
- [x] \`npm run typecheck\` 成功
- [x] \`npm test -- --run\` 成功（624 / 624 テスト）
- [x] \`npm run build\` 成功
- [x] Playwright MCP で G1〜G6 を撮影し新カリキュラム要素を目視確認（\`.playwright-cli/word-en-grade{1-6}.png\`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)