### PR TITLE
feat(print): 実測ベースのA4オーバーフローガードを追加

### DIFF
--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useState } from 'react';
 import type {
   Problem,
   LayoutColumns,
@@ -101,10 +101,14 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
     ref
   ) => {
     // 実測ベースのA4超過検出（プレビュー表示時のみ）
-    const sheetRef = useRef<HTMLDivElement | null>(null);
+    // useState ベースの callback ref を使うことで、要素のマウント時に
+    // 再レンダーが走り、フック内の effect が確実に再実行される
+    const [sheetElement, setSheetElement] = useState<HTMLDivElement | null>(
+      null
+    );
     const setSheetRef = useCallback(
       (node: HTMLDivElement | null): void => {
-        sheetRef.current = node;
+        setSheetElement(node);
         if (typeof ref === 'function') {
           ref(node);
         } else if (ref) {
@@ -114,7 +118,7 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
       [ref]
     );
     const measuredOverflow = useA4SheetOverflow(
-      sheetRef,
+      sheetElement,
       !printMode && problems.length > 0,
       problems
     );

--- a/src/components/Preview/ProblemList.tsx
+++ b/src/components/Preview/ProblemList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import type {
   Problem,
   LayoutColumns,
@@ -35,6 +35,7 @@ import {
   supportsEquationLine,
 } from '../../lib/utils/problem-type-detector';
 import { estimateA4Fit } from '../../lib/utils/print-validator';
+import { useA4SheetOverflow } from './useA4SheetOverflow';
 import { buildPreviewTitle } from '../../lib/utils/previewTitle';
 import {
   emptyA4ContainerStyle,
@@ -99,6 +100,25 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
     },
     ref
   ) => {
+    // 実測ベースのA4超過検出（プレビュー表示時のみ）
+    const sheetRef = useRef<HTMLDivElement | null>(null);
+    const setSheetRef = useCallback(
+      (node: HTMLDivElement | null): void => {
+        sheetRef.current = node;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref]
+    );
+    const measuredOverflow = useA4SheetOverflow(
+      sheetRef,
+      !printMode && problems.length > 0,
+      problems
+    );
+
     if (problems.length === 0) {
       return (
         <div className="flex justify-center py-8 bg-gray-100">
@@ -169,21 +189,28 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
       ...(a4FitResult.fits ? { alignContent: 'space-between', flex: 1 } : {}),
     };
 
+    // 推定（estimateA4Fit）と実測（useA4SheetOverflow）のどちらかが
+    // 超過を検出したら警告を表示する。実測は問題文の折り返しなど
+    // 推定で捉えられない変動を拾うため、実測結果を優先して表示する。
+    const isMeasuredOverflow = measuredOverflow?.isOverflow ?? false;
+    const showOverflowWarning = !a4FitResult.fits || isMeasuredOverflow;
+
     // 印刷モードの場合は外側のラッパーを省略
     const content = (
       <>
         {/* A4オーバーフロー警告 */}
-        {!printMode && !a4FitResult.fits && (
+        {!printMode && showOverflowWarning && (
           <div style={a4WarningContainerStyle}>
             <div style={a4WarningIconRowStyle}>
               <span style={{ fontSize: '20px' }}>⚠️</span>
               <div>
                 <div style={a4WarningTitleStyle}>A4サイズを超えています</div>
                 <div style={a4WarningMessageStyle}>
-                  推定高さ: {a4FitResult.estimatedHeight.toFixed(0)}mm（A4:{' '}
-                  {a4FitResult.a4Height}mm）
+                  {isMeasuredOverflow && measuredOverflow
+                    ? `実測高さ: ${measuredOverflow.heightMm.toFixed(0)}mm（A4: 297mm）— このまま印刷すると2ページ目にはみ出します。`
+                    : `推定高さ: ${a4FitResult.estimatedHeight.toFixed(0)}mm（A4: ${a4FitResult.a4Height}mm）`}
                   <br />
-                  問題数を減らすか、列数を増やしてください。
+                  問題数を減らすか、列数を増やすか、問題を再生成してください。
                 </div>
               </div>
             </div>
@@ -192,13 +219,13 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
 
         {/* A4用紙風のコンテナ */}
         <div
-          ref={ref}
+          ref={setSheetRef}
           data-a4-sheet
           className="bg-white"
           style={getA4ContainerStyle(
             '15mm 15mm 7.5mm',
             printMode,
-            !a4FitResult.fits
+            showOverflowWarning && !printMode
           )}
         >
           {/* ヘッダー */}

--- a/src/components/Preview/WorksheetPreview.tsx
+++ b/src/components/Preview/WorksheetPreview.tsx
@@ -6,6 +6,10 @@ import { ProblemList } from './ProblemList';
 import { MultiPagePrintDialog } from './MultiPagePrintDialog';
 import { useProblemStore } from '../../stores/problemStore';
 import { buildPreviewTitle } from '../../lib/utils/previewTitle';
+import { findOverflowingSheets } from '../../lib/utils/a4-overflow';
+
+/** 印刷前ガードでユーザーが印刷を中止したことを示すエラーメッセージ */
+const PRINT_CANCELLED_BY_OVERFLOW_GUARD = 'print-cancelled-a4-overflow';
 
 interface WorksheetPreviewProps {
   worksheetData?: WorksheetData;
@@ -33,6 +37,36 @@ export const WorksheetPreview: React.FC<WorksheetPreviewProps> = ({
       : '計算プリント',
     onBeforePrint: async () => {
       flushSync(() => setIsPrinting(true));
+
+      // 印刷直前ガード: 描画済みの全ページを実測し、A4を超えるページが
+      // あればユーザーに確認する。気づかずに印刷して紙を無駄にする事故を防ぐ。
+      const printArea = printRef.current;
+      if (printArea) {
+        const overflowing = findOverflowingSheets(printArea);
+        if (overflowing.length > 0) {
+          const worstHeightMm = Math.max(
+            ...overflowing.map((result) => result.heightMm)
+          );
+          const proceed = window.confirm(
+            `${overflowing.length}ページがA4サイズ（297mm）を超えています（最大 ${Math.round(worstHeightMm)}mm）。\n` +
+              'このまま印刷すると問題がはみ出します。\n\n' +
+              '印刷を続けますか？（キャンセルして問題を再生成するか、問題数を減らすことをおすすめします）'
+          );
+          if (!proceed) {
+            setMultiPageWorksheets([]);
+            setIsPrinting(false);
+            // rejectすることで react-to-print が印刷処理を中断する
+            throw new Error(PRINT_CANCELLED_BY_OVERFLOW_GUARD);
+          }
+        }
+      }
+    },
+    onPrintError: (_errorLocation, error) => {
+      if (error.message !== PRINT_CANCELLED_BY_OVERFLOW_GUARD) {
+        console.error('[WorksheetPreview] 印刷エラー:', error);
+      }
+      setMultiPageWorksheets([]);
+      setIsPrinting(false);
     },
     onAfterPrint: () => {
       // 印刷後に複数ページの状態をクリア

--- a/src/components/Preview/WorksheetPreview.tsx
+++ b/src/components/Preview/WorksheetPreview.tsx
@@ -6,7 +6,10 @@ import { ProblemList } from './ProblemList';
 import { MultiPagePrintDialog } from './MultiPagePrintDialog';
 import { useProblemStore } from '../../stores/problemStore';
 import { buildPreviewTitle } from '../../lib/utils/previewTitle';
-import { findOverflowingSheets } from '../../lib/utils/a4-overflow';
+import {
+  findOverflowingSheets,
+  withPrintMediaStyles,
+} from '../../lib/utils/a4-overflow';
 
 /** 印刷前ガードでユーザーが印刷を中止したことを示すエラーメッセージ */
 const PRINT_CANCELLED_BY_OVERFLOW_GUARD = 'print-cancelled-a4-overflow';
@@ -40,9 +43,13 @@ export const WorksheetPreview: React.FC<WorksheetPreviewProps> = ({
 
       // 印刷直前ガード: 描画済みの全ページを実測し、A4を超えるページが
       // あればユーザーに確認する。気づかずに印刷して紙を無駄にする事故を防ぐ。
+      // この時点では印刷メディアが未適用のため、@media print のスタイルを
+      // 一時適用した状態で計測する（画面用CSSでの誤検知を防ぐ）。
       const printArea = printRef.current;
       if (printArea) {
-        const overflowing = findOverflowingSheets(printArea);
+        const overflowing = withPrintMediaStyles(() =>
+          findOverflowingSheets(printArea)
+        );
         if (overflowing.length > 0) {
           const worstHeightMm = Math.max(
             ...overflowing.map((result) => result.heightMm)

--- a/src/components/Preview/__tests__/ProblemList-overflow.test.tsx
+++ b/src/components/Preview/__tests__/ProblemList-overflow.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Problem, WorksheetSettings } from '../../../types';
+import type { A4OverflowResult } from '../../../lib/utils/a4-overflow';
+
+let useA4SheetOverflowMock: Mock<() => A4OverflowResult | null>;
+
+vi.mock('../useA4SheetOverflow', () => ({
+  useA4SheetOverflow: (): A4OverflowResult | null => useA4SheetOverflowMock(),
+}));
+
+import { ProblemList } from '../ProblemList';
+
+const settings: WorksheetSettings = {
+  grade: 4,
+  problemType: 'basic',
+  operation: 'addition',
+  problemCount: 4,
+  layoutColumns: 2,
+};
+
+const problems: Problem[] = Array.from({ length: 4 }, (_, index) => ({
+  id: `p-${index}`,
+  type: 'basic',
+  operation: 'addition',
+  operand1: index + 1,
+  operand2: index + 2,
+  answer: index + index + 3,
+}));
+
+describe('ProblemList 実測ベースのA4オーバーフロー警告', () => {
+  beforeEach(() => {
+    useA4SheetOverflowMock = vi.fn<() => A4OverflowResult | null>(() => null);
+  });
+
+  it('実測が収まっている場合は警告を表示しない', () => {
+    useA4SheetOverflowMock.mockReturnValue({
+      isOverflow: false,
+      heightPx: 1123,
+      heightMm: 297,
+      overflowMm: 0,
+    });
+
+    render(
+      <ProblemList
+        problems={problems}
+        layoutColumns={settings.layoutColumns}
+        settings={settings}
+      />
+    );
+
+    expect(
+      screen.queryByText('A4サイズを超えています')
+    ).not.toBeInTheDocument();
+  });
+
+  it('推定が収まる判定でも実測ではみ出していれば警告を表示する', () => {
+    // 4問2列のbasicは推定では余裕で収まるが、実測がはみ出した状況を再現
+    useA4SheetOverflowMock.mockReturnValue({
+      isOverflow: true,
+      heightPx: 1196,
+      heightMm: 316.4,
+      overflowMm: 19.4,
+    });
+
+    render(
+      <ProblemList
+        problems={problems}
+        layoutColumns={settings.layoutColumns}
+        settings={settings}
+      />
+    );
+
+    expect(screen.getByText('A4サイズを超えています')).toBeInTheDocument();
+    expect(screen.getByText(/実測高さ: 316mm/)).toBeInTheDocument();
+  });
+
+  it('印刷モードでは警告を表示しない', () => {
+    useA4SheetOverflowMock.mockReturnValue({
+      isOverflow: true,
+      heightPx: 1196,
+      heightMm: 316.4,
+      overflowMm: 19.4,
+    });
+
+    render(
+      <ProblemList
+        problems={problems}
+        layoutColumns={settings.layoutColumns}
+        settings={settings}
+        printMode
+      />
+    );
+
+    expect(
+      screen.queryByText('A4サイズを超えています')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Preview/__tests__/WorksheetPreview.test.tsx
+++ b/src/components/Preview/__tests__/WorksheetPreview.test.tsx
@@ -20,8 +20,7 @@ vi.mock(
       options: UseReactToPrintOptions
     ): ((...args: []) => Promise<void> | void) => {
       storedPrintOptions = options;
-      return (...args: []): Promise<void> | void =>
-        mockHandlePrint(...args);
+      return (...args: []): Promise<void> | void => mockHandlePrint(...args);
     },
   })
 );
@@ -38,6 +37,20 @@ vi.mock(
   })
 );
 
+import type { A4OverflowResult } from '../../../lib/utils/a4-overflow';
+
+let findOverflowingSheetsMock: Mock<(root: HTMLElement) => A4OverflowResult[]>;
+
+vi.mock('../../../lib/utils/a4-overflow', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../lib/utils/a4-overflow')>();
+  return {
+    ...actual,
+    findOverflowingSheets: (root: HTMLElement): A4OverflowResult[] =>
+      findOverflowingSheetsMock(root),
+  };
+});
+
 import { WorksheetPreview } from '../WorksheetPreview';
 import { useProblemStore } from '../../../stores/problemStore';
 
@@ -49,14 +62,17 @@ const baseSettings: WorksheetSettings = {
   layoutColumns: 2,
 };
 
-const baseProblems: Problem[] = Array.from({ length: baseSettings.problemCount }, (_, index) => ({
-  id: `base-${index}`,
-  type: 'basic',
-  operation: 'addition',
-  operand1: index + 1,
-  operand2: index + 2,
-  answer: index + index + 3,
-}));
+const baseProblems: Problem[] = Array.from(
+  { length: baseSettings.problemCount },
+  (_, index) => ({
+    id: `base-${index}`,
+    type: 'basic',
+    operation: 'addition',
+    operand1: index + 1,
+    operand2: index + 2,
+    answer: index + index + 3,
+  })
+);
 
 const baseWorksheet: WorksheetData = {
   settings: baseSettings,
@@ -64,14 +80,28 @@ const baseWorksheet: WorksheetData = {
   generatedAt: new Date('2024-01-01T00:00:00Z'),
 };
 
+// 実際の react-to-print と同様に、onBeforePrint の reject で印刷を中断し
+// onPrintError に処理を移す挙動を再現する
+let printProceeded: boolean;
+
 describe('WorksheetPreview multi-page printing', () => {
   beforeEach(() => {
+    printProceeded = false;
     mockHandlePrint = vi.fn<() => Promise<void> | void>(async () => {
-      if (storedPrintOptions?.onBeforePrint) {
-        await storedPrintOptions.onBeforePrint();
+      try {
+        if (storedPrintOptions?.onBeforePrint) {
+          await storedPrintOptions.onBeforePrint();
+        }
+      } catch (error) {
+        storedPrintOptions?.onPrintError?.('onBeforePrint', error as Error);
+        return;
       }
+      printProceeded = true;
       storedPrintOptions?.onAfterPrint?.();
     });
+    findOverflowingSheetsMock = vi.fn<
+      (root: HTMLElement) => A4OverflowResult[]
+    >(() => []);
     generateProblemsMock = vi.fn<(settings: WorksheetSettings) => Problem[]>(
       (settings: WorksheetSettings): Problem[] =>
         Array.from({ length: settings.problemCount }, (_, index) => ({
@@ -124,6 +154,59 @@ describe('WorksheetPreview multi-page printing', () => {
 
     await waitFor(() => {
       expect(screen.getAllByText('名前：')).toHaveLength(1);
+    });
+  });
+
+  describe('A4オーバーフロー印刷前ガード', () => {
+    const overflowResult: A4OverflowResult = {
+      isOverflow: true,
+      heightPx: 1196,
+      heightMm: 316.4,
+      overflowMm: 19.4,
+    };
+
+    async function triggerPrint(): Promise<void> {
+      render(<WorksheetPreview worksheetData={baseWorksheet} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: '印刷（複数ページにも対応）' })
+      );
+      fireEvent.click(screen.getByRole('button', { name: '印刷する' }));
+      await waitFor(() => {
+        expect(mockHandlePrint).toHaveBeenCalledTimes(1);
+      });
+    }
+
+    it('はみ出しがない場合は確認なしで印刷する', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+      await triggerPrint();
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(printProceeded).toBe(true);
+      confirmSpy.mockRestore();
+    });
+
+    it('はみ出し検出時に確認ダイアログでキャンセルすると印刷を中止する', async () => {
+      findOverflowingSheetsMock.mockReturnValue([overflowResult]);
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+      await triggerPrint();
+
+      expect(confirmSpy).toHaveBeenCalledTimes(1);
+      expect(confirmSpy.mock.calls[0][0]).toContain('A4サイズ');
+      expect(printProceeded).toBe(false);
+      confirmSpy.mockRestore();
+    });
+
+    it('はみ出し検出時でもユーザーが続行を選べば印刷する', async () => {
+      findOverflowingSheetsMock.mockReturnValue([overflowResult]);
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+      await triggerPrint();
+
+      expect(confirmSpy).toHaveBeenCalledTimes(1);
+      expect(printProceeded).toBe(true);
+      confirmSpy.mockRestore();
     });
   });
 });

--- a/src/components/Preview/useA4SheetOverflow.ts
+++ b/src/components/Preview/useA4SheetOverflow.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import type { RefObject } from 'react';
+import {
+  evaluateA4Overflow,
+  measureSheetHeightPx,
+} from '../../lib/utils/a4-overflow';
+import type { A4OverflowResult } from '../../lib/utils/a4-overflow';
+
+/**
+ * 描画済みA4シートの実測高さを監視し、A4超過を検出するフック
+ *
+ * estimateA4Fit（定数ベースの推定）が「収まる」と判定しても、
+ * 文章問題の折り返し行数次第で実際にははみ出すことがあるため、
+ * ResizeObserver で実際のDOMの高さを監視する。
+ *
+ * @param sheetRef - [data-a4-sheet] 要素への ref
+ * @param enabled - false の場合は監視しない（印刷モードなど）
+ * @param remeasureKey - 変更時に再計測するキー（問題配列など）
+ */
+export function useA4SheetOverflow(
+  sheetRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+  remeasureKey?: unknown
+): A4OverflowResult | null {
+  const [result, setResult] = useState<A4OverflowResult | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setResult(null);
+      return;
+    }
+    const sheet = sheetRef.current;
+    if (!sheet) {
+      setResult(null);
+      return;
+    }
+
+    const measure = (): void => {
+      setResult(evaluateA4Overflow(measureSheetHeightPx(sheet)));
+    };
+
+    measure();
+
+    // jsdom など ResizeObserver 非対応環境では初回計測のみ
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(sheet);
+    return (): void => observer.disconnect();
+  }, [sheetRef, enabled, remeasureKey]);
+
+  return result;
+}

--- a/src/components/Preview/useA4SheetOverflow.ts
+++ b/src/components/Preview/useA4SheetOverflow.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import type { RefObject } from 'react';
 import {
   evaluateA4Overflow,
   measureSheetHeightPx,
@@ -13,30 +12,30 @@ import type { A4OverflowResult } from '../../lib/utils/a4-overflow';
  * 文章問題の折り返し行数次第で実際にははみ出すことがあるため、
  * ResizeObserver で実際のDOMの高さを監視する。
  *
- * @param sheetRef - [data-a4-sheet] 要素への ref
+ * RefObject ではなく要素そのものを受け取る。RefObject は同一性が
+ * 変わらないため依存配列に入れてもマウント時に effect が再実行されず、
+ * ResizeObserver の監視開始を取りこぼすことがある。呼び出し側は
+ * useState ベースの callback ref で要素を渡すこと。
+ *
+ * @param sheetElement - [data-a4-sheet] 要素（未マウント時は null）
  * @param enabled - false の場合は監視しない（印刷モードなど）
  * @param remeasureKey - 変更時に再計測するキー（問題配列など）
  */
 export function useA4SheetOverflow(
-  sheetRef: RefObject<HTMLElement | null>,
+  sheetElement: HTMLElement | null,
   enabled: boolean,
   remeasureKey?: unknown
 ): A4OverflowResult | null {
   const [result, setResult] = useState<A4OverflowResult | null>(null);
 
   useEffect(() => {
-    if (!enabled) {
-      setResult(null);
-      return;
-    }
-    const sheet = sheetRef.current;
-    if (!sheet) {
+    if (!enabled || !sheetElement) {
       setResult(null);
       return;
     }
 
     const measure = (): void => {
-      setResult(evaluateA4Overflow(measureSheetHeightPx(sheet)));
+      setResult(evaluateA4Overflow(measureSheetHeightPx(sheetElement)));
     };
 
     measure();
@@ -47,9 +46,9 @@ export function useA4SheetOverflow(
     }
 
     const observer = new ResizeObserver(measure);
-    observer.observe(sheet);
+    observer.observe(sheetElement);
     return (): void => observer.disconnect();
-  }, [sheetRef, enabled, remeasureKey]);
+  }, [sheetElement, enabled, remeasureKey]);
 
   return result;
 }

--- a/src/lib/utils/__tests__/a4-overflow.test.ts
+++ b/src/lib/utils/__tests__/a4-overflow.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  A4_HEIGHT_PX,
+  A4_OVERFLOW_TOLERANCE_PX,
+  evaluateA4Overflow,
+  measureSheetHeightPx,
+  findOverflowingSheets,
+} from '../a4-overflow';
+
+/** テスト用に高さを偽装したシート要素を作る */
+function createSheet(heightPx: number): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('data-a4-sheet', '');
+  Object.defineProperty(el, 'scrollHeight', {
+    value: heightPx,
+    configurable: true,
+  });
+  el.getBoundingClientRect = (): DOMRect => ({ height: heightPx }) as DOMRect;
+  return el;
+}
+
+describe('evaluateA4Overflow', () => {
+  it('A4ちょうどの高さは収まる判定になる', () => {
+    const result = evaluateA4Overflow(A4_HEIGHT_PX);
+    expect(result.isOverflow).toBe(false);
+    expect(result.overflowMm).toBe(0);
+  });
+
+  it('許容誤差内（+5px）は収まる判定になる', () => {
+    const result = evaluateA4Overflow(A4_HEIGHT_PX + A4_OVERFLOW_TOLERANCE_PX);
+    expect(result.isOverflow).toBe(false);
+  });
+
+  it('許容誤差を超えるとはみ出し判定になる', () => {
+    const result = evaluateA4Overflow(
+      A4_HEIGHT_PX + A4_OVERFLOW_TOLERANCE_PX + 1
+    );
+    expect(result.isOverflow).toBe(true);
+    expect(result.overflowMm).toBeGreaterThan(0);
+  });
+
+  it('実測したword-enのはみ出しケース（1196px ≒ A4の106.5%）を検出する', () => {
+    const result = evaluateA4Overflow(1196);
+    expect(result.isOverflow).toBe(true);
+    expect(result.heightMm).toBeCloseTo(316.4, 0);
+    expect(result.overflowMm).toBeCloseTo(19.4, 0);
+  });
+});
+
+describe('measureSheetHeightPx', () => {
+  it('boundingClientRect と scrollHeight の大きい方を返す', () => {
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'scrollHeight', { value: 1200 });
+    el.getBoundingClientRect = (): DOMRect => ({ height: 1123 }) as DOMRect;
+    expect(measureSheetHeightPx(el)).toBe(1200);
+  });
+});
+
+describe('findOverflowingSheets', () => {
+  it('複数シートからはみ出しているものだけを返す', () => {
+    const root = document.createElement('div');
+    root.appendChild(createSheet(1123)); // 収まる
+    root.appendChild(createSheet(1196)); // はみ出し
+    root.appendChild(createSheet(1500)); // はみ出し
+
+    const results = findOverflowingSheets(root);
+    expect(results).toHaveLength(2);
+    expect(results[0].heightPx).toBe(1196);
+    expect(results[1].heightPx).toBe(1500);
+  });
+
+  it('全シートが収まっている場合は空配列を返す', () => {
+    const root = document.createElement('div');
+    root.appendChild(createSheet(1000));
+    root.appendChild(createSheet(1123));
+    expect(findOverflowingSheets(root)).toHaveLength(0);
+  });
+
+  it('シートが存在しない場合は空配列を返す', () => {
+    const root = document.createElement('div');
+    expect(findOverflowingSheets(root)).toHaveLength(0);
+  });
+});

--- a/src/lib/utils/__tests__/a4-overflow.test.ts
+++ b/src/lib/utils/__tests__/a4-overflow.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateA4Overflow,
   measureSheetHeightPx,
   findOverflowingSheets,
+  withPrintMediaStyles,
 } from '../a4-overflow';
 
 /** テスト用に高さを偽装したシート要素を作る */
@@ -79,5 +80,52 @@ describe('findOverflowingSheets', () => {
   it('シートが存在しない場合は空配列を返す', () => {
     const root = document.createElement('div');
     expect(findOverflowingSheets(root)).toHaveLength(0);
+  });
+});
+
+describe('withPrintMediaStyles', () => {
+  it('実行中だけ @media print のルールを一時スタイルとして適用し、終了後に除去する', () => {
+    const style = document.createElement('style');
+    style.textContent = '@media print { .problem-text { font-size: 10px; } }';
+    document.head.appendChild(style);
+
+    let stylesDuringCallback = 0;
+    const result = withPrintMediaStyles(() => {
+      stylesDuringCallback = document.querySelectorAll(
+        'style[data-print-measure]'
+      ).length;
+      return 42;
+    });
+
+    expect(result).toBe(42);
+    expect(stylesDuringCallback).toBe(1);
+    expect(document.querySelector('style[data-print-measure]')).toBeNull();
+    style.remove();
+  });
+
+  it('コールバックが例外を投げても一時スタイルを除去する', () => {
+    const style = document.createElement('style');
+    style.textContent = '@media print { body { margin: 0; } }';
+    document.head.appendChild(style);
+
+    expect(() =>
+      withPrintMediaStyles(() => {
+        throw new Error('boom');
+      })
+    ).toThrow('boom');
+    expect(document.querySelector('style[data-print-measure]')).toBeNull();
+    style.remove();
+  });
+
+  it('printルールが無い場合はスタイルを追加せずコールバックを実行する', () => {
+    let stylesDuringCallback = 0;
+    const result = withPrintMediaStyles(() => {
+      stylesDuringCallback = document.querySelectorAll(
+        'style[data-print-measure]'
+      ).length;
+      return 'ok';
+    });
+    expect(result).toBe('ok');
+    expect(stylesDuringCallback).toBe(0);
   });
 });

--- a/src/lib/utils/a4-overflow.ts
+++ b/src/lib/utils/a4-overflow.ts
@@ -67,3 +67,51 @@ export function findOverflowingSheets(root: HTMLElement): A4OverflowResult[] {
     .map((sheet) => evaluateA4Overflow(measureSheetHeightPx(sheet)))
     .filter((result) => result.isOverflow);
 }
+
+/**
+ * コールバック実行中だけ @media print のスタイルを強制適用する
+ *
+ * onBeforePrint 時点ではブラウザの印刷メディアがまだ有効でないため、
+ * 画面用CSS（印刷時より大きいフォント等）で実測すると印刷時には
+ * 収まるページを誤ってはみ出し判定してしまう。同一オリジンの
+ * 全スタイルシートから @media print 内のルールを抽出し、一時的な
+ * <style> 要素として適用した状態で計測する。
+ */
+export function withPrintMediaStyles<T>(callback: () => T): T {
+  const printRules: string[] = [];
+
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      // クロスオリジンのスタイルシートは読めないためスキップ
+      continue;
+    }
+    for (const rule of Array.from(rules)) {
+      if (rule instanceof CSSMediaRule) {
+        // conditionText 非対応環境（jsdom等）では media.mediaText を使う
+        const condition = rule.conditionText || rule.media.mediaText;
+        if (/(^|,)\s*print\s*($|,)/.test(condition)) {
+          for (const inner of Array.from(rule.cssRules)) {
+            printRules.push(inner.cssText);
+          }
+        }
+      }
+    }
+  }
+
+  if (printRules.length === 0) {
+    return callback();
+  }
+
+  const styleElement = document.createElement('style');
+  styleElement.setAttribute('data-print-measure', '');
+  styleElement.textContent = printRules.join('\n');
+  document.head.appendChild(styleElement);
+  try {
+    return callback();
+  } finally {
+    styleElement.remove();
+  }
+}

--- a/src/lib/utils/a4-overflow.ts
+++ b/src/lib/utils/a4-overflow.ts
@@ -1,0 +1,69 @@
+/**
+ * A4オーバーフロー実測ユーティリティ
+ *
+ * estimateA4Fit（定数ベースの推定）と異なり、実際に描画された
+ * [data-a4-sheet] 要素の高さを測ってA4超過を判定する。
+ * 問題文の折り返し行数など、推定では捉えられない変動を検出できる。
+ */
+
+import {
+  A4_HEIGHT_MM,
+  MM_PER_PX,
+  PX_PER_MM,
+} from '../../components/Export/fitPageToA4';
+
+/** A4の高さ（px @ 96dpi）。check-print-layout.mjs と同じ基準 */
+export const A4_HEIGHT_PX = A4_HEIGHT_MM * PX_PER_MM;
+
+/** 許容誤差（px）。check-print-layout.mjs の TOLERANCE_PX と揃える */
+export const A4_OVERFLOW_TOLERANCE_PX = 5;
+
+export interface A4OverflowResult {
+  /** A4の高さを許容誤差を超えて上回っている場合 true */
+  isOverflow: boolean;
+  /** 実測高さ（px） */
+  heightPx: number;
+  /** 実測高さ（mm） */
+  heightMm: number;
+  /** はみ出し量（mm）。収まっている場合は 0 */
+  overflowMm: number;
+}
+
+/**
+ * 実測高さ（px）からA4超過を判定する
+ */
+export function evaluateA4Overflow(heightPx: number): A4OverflowResult {
+  const overflowPx = heightPx - A4_HEIGHT_PX;
+  const isOverflow = overflowPx > A4_OVERFLOW_TOLERANCE_PX;
+  return {
+    isOverflow,
+    heightPx,
+    heightMm: heightPx * MM_PER_PX,
+    overflowMm: isOverflow ? overflowPx * MM_PER_PX : 0,
+  };
+}
+
+/**
+ * シート要素の実測高さ（px）を取得する
+ *
+ * minHeight 固定のコンテナでも内容のはみ出しを拾えるよう、
+ * boundingClientRect と scrollHeight の大きい方を採用する。
+ */
+export function measureSheetHeightPx(sheet: HTMLElement): number {
+  return Math.max(sheet.getBoundingClientRect().height, sheet.scrollHeight);
+}
+
+/**
+ * ルート要素配下の全 [data-a4-sheet] を実測し、A4を超えるシートを返す
+ *
+ * 複数枚印刷では1ページごとに別のシートが描画されるため、
+ * 印刷直前のガードはこの関数で全ページを検査する。
+ */
+export function findOverflowingSheets(root: HTMLElement): A4OverflowResult[] {
+  const sheets = Array.from(
+    root.querySelectorAll<HTMLElement>('[data-a4-sheet]')
+  );
+  return sheets
+    .map((sheet) => evaluateA4Overflow(measureSheetHeightPx(sheet)))
+    .filter((result) => result.isOverflow);
+}


### PR DESCRIPTION
## 概要

PDFのA4はみ出しが繰り返し再発する問題（直近では4年生word-en）への根本対策の第1弾です。

これまでのA4判定は `minProblemHeight` 定数ベースの**推定**のみで、word-en など問題文の折り返し行数で実際の高さが変動するタイプでは、**警告が出ないまま印刷がはみ出す**ことがありました。デプロイ済みサイトでの実測では、4年生word-enは3回生成中1回がA4の106.5%にはみ出し、プレビュー警告は表示されませんでした。

本PRは「推定」ではなく「描画済みDOMの実測」を判定の真実とするガードを追加します。

## 変更内容

- **`src/lib/utils/a4-overflow.ts`**: `[data-a4-sheet]` の実測高さでA4超過を判定する純関数ユーティリティ（許容誤差は `check-print-layout.mjs` と同じ5px基準）
- **`useA4SheetOverflow`**: ResizeObserver でプレビューのシート高さを監視するフック
- **`ProblemList`**: 推定（estimateA4Fit）に加えて実測でも警告バナーを表示。実測超過時は実測値を優先表示
- **`WorksheetPreview`**: 印刷直前（onBeforePrint）に複数枚印刷分を含む全ページを実測し、はみ出しページがあれば confirm で印刷を中止できるガードを追加（reject により react-to-print が印刷を中断）

## 検証

- `npm run lint` / `npm run typecheck` / `npm test -- --run`（640件）/ `npm run build` すべて成功
- ローカルビルド + Playwright で実機確認:
  - 4年生word-enのはみ出し発生時、プレビューに「実測高さ: 308mm（A4: 297mm）」の警告バナーと赤枠が表示される
  - 印刷実行時に confirm「3ページがA4サイズ（297mm）を超えています」が表示され、キャンセルで印刷が中止される（プレビューに見えない複数枚印刷の2枚目以降も検出）
  - はみ出しがない場合は confirm なしで従来どおり印刷

## 今後の予定（別PR）

1. 印刷パスに `fitPageToA4`（余白削減→縮小スケーリング）を接続して自動フィット
2. `check-print-layout.mjs` のシナリオをテンプレート定義から自動列挙（word-en全学年カバー＋複数回生成）
3. word-en ジェネレータの問題文に学年別文字数バジェットの unit test を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)