### PR TITLE
fix(ui): アコーディオンの展開コンテンツが多項目カテゴリで切れる問題を修正 (#76)

### DIFF
--- a/src/components/UI/Accordion.tsx
+++ b/src/components/UI/Accordion.tsx
@@ -133,7 +133,7 @@ function AccordionItemComponent({
             : 'grid-rows-[0fr] opacity-0'
         }`}
       >
-        <div className="overflow-hidden">
+        <div className="overflow-hidden min-h-0">
           <div className="px-4 pb-4 pt-2 border-t border-slate-100">
             {item.children}
           </div>

--- a/src/components/UI/Accordion.tsx
+++ b/src/components/UI/Accordion.tsx
@@ -38,7 +38,9 @@ export function Accordion({
 
   // 制御モードか非制御モードかを判定
   const isControlled = controlledExpandedIds !== undefined;
-  const expandedIds = isControlled ? controlledExpandedIds : internalExpandedIds;
+  const expandedIds = isControlled
+    ? controlledExpandedIds
+    : internalExpandedIds;
 
   const toggleItem = useCallback(
     (itemId: string) => {
@@ -121,14 +123,20 @@ function AccordionItemComponent({
         </svg>
       </button>
 
-      {/* コンテンツ（展開時のみ表示） */}
+      {/* コンテンツ（展開時のみ表示）
+          高さに依存しない grid-rows トランジションで、パターン数が増えても
+          下部が切れないようにする（旧 max-h-[1000px] はクランプで欠落していた） */}
       <div
-        className={`overflow-hidden transition-all duration-200 ${
-          isExpanded ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'
+        className={`grid transition-all duration-200 ${
+          isExpanded
+            ? 'grid-rows-[1fr] opacity-100'
+            : 'grid-rows-[0fr] opacity-0'
         }`}
       >
-        <div className="px-4 pb-4 pt-2 border-t border-slate-100">
-          {item.children}
+        <div className="overflow-hidden">
+          <div className="px-4 pb-4 pt-2 border-t border-slate-100">
+            {item.children}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/UI/__tests__/Accordion.test.tsx
+++ b/src/components/UI/__tests__/Accordion.test.tsx
@@ -154,7 +154,8 @@ describe('Accordion', () => {
 
       const clamped = container.querySelectorAll('[class*="max-h-["]');
       const offenders = [...clamped]
-        .map((el) => el.className)
+        // Element.className can be SVGAnimatedString; getAttribute is always string
+        .map((el) => el.getAttribute('class') || '')
         .filter((cls) => /max-h-\[\d+px\]/.test(cls));
 
       expect(offenders).toEqual([]);

--- a/src/components/UI/__tests__/Accordion.test.tsx
+++ b/src/components/UI/__tests__/Accordion.test.tsx
@@ -57,16 +57,22 @@ describe('Accordion', () => {
     it('should toggle item on click', () => {
       render(<Accordion items={mockItems} defaultOpen={[]} />);
 
-      const firstItemButton = screen.getByRole('button', { name: /First Item/i });
+      const firstItemButton = screen.getByRole('button', {
+        name: /First Item/i,
+      });
       fireEvent.click(firstItemButton);
 
       expect(screen.getByText('Content 1')).toBeInTheDocument();
     });
 
     it('should allow multiple items expanded when allowMultiple is true', () => {
-      render(<Accordion items={mockItems} defaultOpen={['item1']} allowMultiple />);
+      render(
+        <Accordion items={mockItems} defaultOpen={['item1']} allowMultiple />
+      );
 
-      const secondItemButton = screen.getByRole('button', { name: /Second Item/i });
+      const secondItemButton = screen.getByRole('button', {
+        name: /Second Item/i,
+      });
       fireEvent.click(secondItemButton);
 
       expect(screen.getByText('Content 1')).toBeInTheDocument();
@@ -75,10 +81,16 @@ describe('Accordion', () => {
 
     it('should collapse other items when allowMultiple is false', () => {
       render(
-        <Accordion items={mockItems} defaultOpen={['item1']} allowMultiple={false} />
+        <Accordion
+          items={mockItems}
+          defaultOpen={['item1']}
+          allowMultiple={false}
+        />
       );
 
-      const secondItemButton = screen.getByRole('button', { name: /Second Item/i });
+      const secondItemButton = screen.getByRole('button', {
+        name: /Second Item/i,
+      });
       fireEvent.click(secondItemButton);
 
       // Only item2 should be visible now
@@ -103,7 +115,9 @@ describe('Accordion', () => {
         />
       );
 
-      const firstItemButton = screen.getByRole('button', { name: /First Item/i });
+      const firstItemButton = screen.getByRole('button', {
+        name: /First Item/i,
+      });
       fireEvent.click(firstItemButton);
 
       expect(onExpandChange).toHaveBeenCalledWith(['item1']);
@@ -119,10 +133,31 @@ describe('Accordion', () => {
         />
       );
 
-      const firstItemButton = screen.getByRole('button', { name: /First Item/i });
+      const firstItemButton = screen.getByRole('button', {
+        name: /First Item/i,
+      });
       fireEvent.click(firstItemButton);
 
       expect(onExpandChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('layout regression', () => {
+    // 回帰: 展開コンテンツを固定px高さ（max-h-[1000px] 等）でクランプすると、
+    // パターン数が増えたカテゴリで下部が overflow-hidden により欠落する。
+    // grade1 で +3〜+9 追加後に「+9 の下が表示されない」不具合が発生したため、
+    // 固定px高さクランプの再導入をこのテストで禁止する。
+    it('should not clamp expanded content with a fixed pixel max-height', () => {
+      const { container } = render(
+        <Accordion items={mockItems} defaultOpen={['item1']} />
+      );
+
+      const clamped = container.querySelectorAll('[class*="max-h-["]');
+      const offenders = [...clamped]
+        .map((el) => el.className)
+        .filter((cls) => /max-h-\[\d+px\]/.test(cls));
+
+      expect(offenders).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

- 1年生「基本計算」カテゴリが PR #74 で 22 項目（約 1583px）に拡張された結果、固定高さ `max-h-[1000px]` による `overflow-hidden` クランプで下部項目（+9 以降）が画面から欠落していた
- アコーディオン展開アニメーションを `max-h` 固定値方式から高さ非依存の `grid-rows` トランジション方式に変更し、項目数が増えても切れないよう修正
- 固定 px 高さクランプの再導入を検出する回帰テストを追加

## Related Issue

Related to #74 (grade1 +3〜+9 パターン追加で顕在化)

## Changes Made

### Fixed

- `Accordion.tsx`: `max-h-[1000px]` / `max-h-0` の固定高さクランプを廃止し、`grid-rows-[1fr]` / `grid-rows-[0fr]` トランジションへ置換
- 展開コンテンツを `grid > div.overflow-hidden > div.content` の 3 層構造に変更（grid-rows アニメーションに必要）

### Added

- `Accordion.test.tsx`: `layout regression` スイート — `max-h-[\d+px]` クラスが展開コンテンツに存在する場合に失敗する回帰テストを追加（14 テスト中の新規 1 件）

## Technical Details

### Implementation Approach

Tailwind CSS の `grid-rows-[0fr]` / `grid-rows-[1fr]` トランジションは、コンテンツの実高さを事前に知らなくてもスムーズな開閉アニメーションを実現できる。内側の `div` に `overflow-hidden` を付けることで `0fr` 時に完全非表示になり、旧 `max-h` 方式と同等の見た目を維持しつつ、高さの上限が存在しない。

### Key Changes

- **`src/components/UI/Accordion.tsx`** — 展開コンテナのクラスを `overflow-hidden max-h-[1000px]/max-h-0` から `grid grid-rows-[1fr]/grid-rows-[0fr]` へ変更。内側に `overflow-hidden` ラッパーを追加
- **`src/components/UI/__tests__/Accordion.test.tsx`** — `layout regression` describe ブロックを追加。`querySelectorAll('[class*="max-h-["]')` で固定 px クランプ要素を検索し、`/max-h-\[\d+px\]/` にマッチするクラスがあれば失敗

### Breaking Changes

なし（Accordion の外部 API・props に変更なし）

## Test Results

### Unit Tests

- 663 / 663 テストパス（`npm test -- --run` で確認）
- Accordion テスト: 14 件（回帰テスト 1 件を含む）

### Playwright 実測

- grade1「基本計算（22 項目）」のアコーディオンを展開し `clientHeight === scrollHeight`（1583px）を確認
- `clipped: false` — 下部コンテンツの欠落なし

## Review Focus

### Critical

- **`grid-rows` トランジションのブラウザ互換性**: `grid-rows-[0fr]` / `grid-rows-[1fr]` アニメーションは Chrome / Firefox / Safari の最新版で動作するが、旧 `max-h` 方式の代替として全対象ブラウザで意図通りに動くか確認
- **`overflow-hidden` の追加レイヤー**: 3 層構造（`grid > overflow-hidden-div > content`）が既存スタイルや子コンポーネントのレイアウトに影響していないか

### Important

- **回帰テストの正規表現**: `/max-h-\[\d+px\]/` が将来の固定 px 再導入を適切に捕捉するか（例: `max-h-[2000px]` は検出されるが `max-h-screen` は意図的に除外）

## Verification Steps

1. `git checkout fix/grade1-accordion-clipping` でブランチをチェックアウト
2. `npm install` で依存関係をインストール
3. `npm test -- --run` で全テスト（663 件）がパスすることを確認
4. `npm run dev` で開発サーバー起動
5. 学年セレクターで「1年生」を選択
6. 計算パターンセレクターの「基本計算」カテゴリを展開し、+3〜+9 のパターン（最下部）まですべて表示されることを確認
7. アコーディオンを閉じて再度開き、アニメーションが正常に動作することを確認

## Checklist

- [x] コードはプロジェクトのスタイルガイドラインに従っている
- [x] セルフレビュー完了
- [x] 複雑なロジックにコメントを追加済み
- [x] 回帰テスト追加済み
- [x] 全テスト（663 件）パス
- [x] `npm run lint` 成功
- [x] `npm run typecheck` 成功
- [x] `npm run build` 成功
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)