### PR TITLE
feat(grade1): add mixed carry/no-carry single-digit addition pattern

### DIFF
--- a/src/config/pattern-categories.ts
+++ b/src/config/pattern-categories.ts
@@ -166,6 +166,7 @@ const BASE_DIFFICULTY: Partial<Record<CalculationPattern, DifficultyLevel>> = {
   'sub-single-digit': 1,
   'sub-from-10': 1,
   'add-single-digit-carry': 2,
+  'add-single-digit-mixed': 3,
   'sub-single-digit-borrow': 2,
   'add-sub-mixed-basic': 3,
   'add-single-missing': 3,

--- a/src/lib/generators/patterns/grade1-beginner.test.ts
+++ b/src/lib/generators/patterns/grade1-beginner.test.ts
@@ -12,6 +12,7 @@ import {
   generateAddCounting,
   generateCountingAdd,
   generateCountingSub,
+  generateAddSingleDigitMixed,
 } from './grade1';
 import type { WorksheetSettings } from '../../../types';
 
@@ -206,5 +207,51 @@ describe('generateCountingSub (○を使ったひき算)', () => {
       expect(problem.problemText).toContain('のこりは いくつ？');
       expect(problem.answer).toBeGreaterThanOrEqual(1);
     });
+  });
+});
+
+describe('generateAddSingleDigitMixed (繰り上がり混在のたし算)', () => {
+  it('should generate single-digit additions within 20', () => {
+    const problems = generateAddSingleDigitMixed(baseSettings, 20);
+
+    expect(problems).toHaveLength(20);
+    problems.forEach((problem) => {
+      expect(problem.type).toBe('basic');
+      expect(problem.operation).toBe('addition');
+      expect(problem.operand1).toBeGreaterThanOrEqual(1);
+      expect(problem.operand1).toBeLessThanOrEqual(9);
+      expect(problem.operand2!).toBeGreaterThanOrEqual(1);
+      expect(problem.operand2!).toBeLessThanOrEqual(9);
+      expect(problem.answer).toBe(problem.operand1! + problem.operand2!);
+      expect(problem.answer).toBeLessThanOrEqual(18);
+      // ちょうど10は繰り上がり扱いしない（grade1パターンの規約）
+      expect(problem.carryOver).toBe(problem.answer! > 10);
+    });
+  });
+
+  it('should mix carry and non-carry problems in the same worksheet', () => {
+    // 45通り中20通り（約44%）が繰り上がり。20問なら両方が出る確率は非常に高い
+    for (let trial = 0; trial < 5; trial++) {
+      const problems = generateAddSingleDigitMixed(baseSettings, 20);
+      expect(problems.some((p) => p.carryOver)).toBe(true);
+      expect(problems.some((p) => !p.carryOver)).toBe(true);
+    }
+  });
+
+  it('should not repeat the same combination within one worksheet (30問)', () => {
+    const problems = generateAddSingleDigitMixed(baseSettings, 30);
+    const keys = problems.map((p) => {
+      const [a, b] = [p.operand1!, p.operand2!].sort((x, y) => x - y);
+      return `${a}+${b}`;
+    });
+    expect(new Set(keys).size).toBe(30);
+  });
+
+  it('should place the larger operand on either side across problems', () => {
+    // 45通り全てを出し切れば、順序ランダム化により
+    // operand1 > operand2 の問題と operand1 < operand2 の問題が両方現れる
+    const problems = generateAddSingleDigitMixed(baseSettings, 45);
+    expect(problems.some((p) => p.operand1! > p.operand2!)).toBe(true);
+    expect(problems.some((p) => p.operand1! < p.operand2!)).toBe(true);
   });
 });

--- a/src/lib/generators/patterns/grade1-beginner.test.ts
+++ b/src/lib/generators/patterns/grade1-beginner.test.ts
@@ -229,13 +229,31 @@ describe('generateAddSingleDigitMixed (繰り上がり混在のたし算)', () =
     });
   });
 
-  it('should mix carry and non-carry problems in the same worksheet', () => {
-    // 45通り中20通り（約44%）が繰り上がり。20問なら両方が出る確率は非常に高い
-    for (let trial = 0; trial < 5; trial++) {
-      const problems = generateAddSingleDigitMixed(baseSettings, 20);
-      expect(problems.some((p) => p.carryOver)).toBe(true);
-      expect(problems.some((p) => !p.carryOver)).toBe(true);
+  it('should always mix carry and non-carry problems, even at small counts', () => {
+    // シャッフル任せだと5問プリントは約5.6%の確率で片方のクラスだけになるため、
+    // 各クラス1問ずつを構造的に保証している。UIの最小問題数5問を含めて検証
+    for (const count of [2, 5, 10, 20]) {
+      for (let trial = 0; trial < 30; trial++) {
+        const problems = generateAddSingleDigitMixed(baseSettings, count);
+        expect(problems).toHaveLength(count);
+        expect(problems.some((p) => p.carryOver)).toBe(true);
+        expect(problems.some((p) => !p.carryOver)).toBe(true);
+      }
     }
+  });
+
+  it('should not always place the guaranteed pair at the first two positions', () => {
+    // 確保した2問を先頭固定にすると出題順が予測可能になるため、
+    // 選択後に並びをシャッフルしている
+    const firstTwoAlwaysDifferentClass = Array.from({ length: 30 }, () =>
+      generateAddSingleDigitMixed(baseSettings, 20)
+    ).every((problems) => problems[0].carryOver !== problems[1].carryOver);
+    expect(firstTwoAlwaysDifferentClass).toBe(false);
+  });
+
+  it('should handle counts below the guarantee threshold', () => {
+    expect(generateAddSingleDigitMixed(baseSettings, 0)).toHaveLength(0);
+    expect(generateAddSingleDigitMixed(baseSettings, 1)).toHaveLength(1);
   });
 
   it('should not repeat the same combination within one worksheet (30問)', () => {

--- a/src/lib/generators/patterns/grade1.ts
+++ b/src/lib/generators/patterns/grade1.ts
@@ -360,23 +360,44 @@ export function generateAddSingleDigitMixed(
   _settings: WorksheetSettings,
   count: number
 ): BasicProblem[] {
-  // 1〜9同士の組み合わせ（順序違いは同一とみなす）を全列挙してシャッフル
-  // 45通りのうち20通り（約44%）が繰り上がりになる
-  const pool: [number, number][] = [];
+  // 1〜9同士の組み合わせ（順序違いは同一とみなす）を全45通り列挙し、
+  // 繰り上がりあり20通り / なし25通りに分ける
+  const carryPairs: [number, number][] = [];
+  const noCarryPairs: [number, number][] = [];
   for (let a = 1; a <= 9; a++) {
     for (let b = a; b <= 9; b++) {
-      pool.push([a, b]);
+      (a + b > 10 ? carryPairs : noCarryPairs).push([a, b]);
     }
   }
-  shuffleArray(pool);
+  shuffleArray(carryPairs);
+  shuffleArray(noCarryPairs);
 
-  const problems: BasicProblem[] = [];
-  for (let i = 0; i < count; i++) {
+  // 2問以上なら各クラスから1問ずつを先に確保する。
+  // シャッフル任せだと少問数（1列は最小5問）のとき数%の確率で
+  // 全問が同じクラスになり、「混在」と銘打ったプリントとして成立しない
+  const selected: [number, number][] = [];
+  if (count >= 2) {
+    selected.push(carryPairs.pop()!, noCarryPairs.pop()!);
+  }
+
+  // 残りは両クラス混合のプールから。確保済みの2問はプールから除かれているので
+  // 重複は起きない
+  const guaranteedCount = selected.length;
+  const pool = [...carryPairs, ...noCarryPairs];
+  shuffleArray(pool);
+  for (let poolIndex = 0; poolIndex < count - guaranteedCount; poolIndex++) {
     // プールを使い切ったら再シャッフルして構造的重複を防ぐ
-    if (i > 0 && i % pool.length === 0) {
+    if (poolIndex > 0 && poolIndex % pool.length === 0) {
       shuffleArray(pool);
     }
-    const [a, b] = pool[i % pool.length];
+    selected.push(pool[poolIndex % pool.length]);
+  }
+
+  // 確保した2問が常に第1問・第2問に来ないよう出題順をシャッフル
+  shuffleArray(selected);
+
+  const problems: BasicProblem[] = [];
+  for (const [a, b] of selected) {
     // 「3＋8」「8＋3」のどちらも出るように出題順をランダム化
     const swap = randomInt(0, 1) === 1;
     const operand1 = swap ? b : a;

--- a/src/lib/generators/patterns/grade1.ts
+++ b/src/lib/generators/patterns/grade1.ts
@@ -355,6 +355,49 @@ export function generateAddSingleDigitCarry(
   return problems;
 }
 
+// 1年生: 1桁のたし算（繰り上がりあり・なし混在、20まで）
+export function generateAddSingleDigitMixed(
+  _settings: WorksheetSettings,
+  count: number
+): BasicProblem[] {
+  // 1〜9同士の組み合わせ（順序違いは同一とみなす）を全列挙してシャッフル
+  // 45通りのうち20通り（約44%）が繰り上がりになる
+  const pool: [number, number][] = [];
+  for (let a = 1; a <= 9; a++) {
+    for (let b = a; b <= 9; b++) {
+      pool.push([a, b]);
+    }
+  }
+  shuffleArray(pool);
+
+  const problems: BasicProblem[] = [];
+  for (let i = 0; i < count; i++) {
+    // プールを使い切ったら再シャッフルして構造的重複を防ぐ
+    if (i > 0 && i % pool.length === 0) {
+      shuffleArray(pool);
+    }
+    const [a, b] = pool[i % pool.length];
+    // 「3＋8」「8＋3」のどちらも出るように出題順をランダム化
+    const swap = randomInt(0, 1) === 1;
+    const operand1 = swap ? b : a;
+    const operand2 = swap ? a : b;
+
+    problems.push({
+      id: generateId(),
+      type: 'basic',
+      operation: 'addition',
+      operand1,
+      operand2,
+      answer: operand1 + operand2,
+      // grade1パターンの規約: ちょうど10は「10をつくる計算」であり
+      // 繰り上がり扱いしない（generateAddSingleDigitCarry と同じ基準）
+      carryOver: operand1 + operand2 > 10,
+    });
+  }
+
+  return problems;
+}
+
 // 1年生: 10を作る計算
 export function generateAddTo10(
   _settings: WorksheetSettings,

--- a/src/lib/generators/patterns/index.ts
+++ b/src/lib/generators/patterns/index.ts
@@ -50,6 +50,7 @@ import {
   generateCountingSub,
   generateAddSingleDigit,
   generateAddSingleDigitCarry,
+  generateAddSingleDigitMixed,
   generateAddTo10,
   generateAdd10Plus,
   generateSubSingleDigit,
@@ -175,6 +176,8 @@ export function generatePatternProblems(
       return generateAddSingleDigit(settings, count);
     case 'add-single-digit-carry':
       return generateAddSingleDigitCarry(settings, count);
+    case 'add-single-digit-mixed':
+      return generateAddSingleDigitMixed(settings, count);
     case 'add-to-10':
       return generateAddTo10(settings, count);
     case 'add-10-plus':

--- a/src/types/calculation-patterns.ts
+++ b/src/types/calculation-patterns.ts
@@ -16,6 +16,7 @@ export type CalculationPattern =
   // 1年生のパターン
   | 'add-single-digit' // 1桁＋1桁（答えが10まで）
   | 'add-single-digit-carry' // 1桁＋1桁（繰り上がりあり、答えが20まで）
+  | 'add-single-digit-mixed' // 1桁＋1桁（繰り上がりあり・なし混在、答えが20まで）
   | 'add-to-10' // 10を作る計算（□＋△＝10）
   | 'add-10-plus' // 10＋□の計算
   | 'sub-single-digit' // 1桁－1桁（繰り下がりなし）
@@ -199,6 +200,7 @@ export const PATTERNS_BY_GRADE: Record<number, CalculationPattern[]> = {
     'counting-sub',
     'add-single-digit',
     'add-single-digit-carry',
+    'add-single-digit-mixed',
     'add-to-10',
     'add-10-plus',
     'sub-single-digit',
@@ -551,6 +553,7 @@ export const PATTERN_LABELS: Record<CalculationPattern, string> = {
   // 1年生
   'add-single-digit': '1桁のたし算（10まで）',
   'add-single-digit-carry': '1桁のたし算（繰り上がりあり）',
+  'add-single-digit-mixed': '1桁のたし算（繰り上がり混在）',
   'add-to-10': '10を作る計算',
   'add-10-plus': '10＋□の計算',
   'sub-single-digit': '1桁のひき算（繰り下がりなし）',
@@ -736,6 +739,7 @@ export const PATTERN_DESCRIPTIONS: Record<CalculationPattern, string> = {
   // 1年生
   'add-single-digit': '5＋3などの基本的なたし算',
   'add-single-digit-carry': '8＋7などの繰り上がりのあるたし算',
+  'add-single-digit-mixed': '3＋4と8＋7が混ざったたし算',
   'add-to-10': '□＋△＝10になる組み合わせ',
   'add-10-plus': '10＋5などの計算',
   'sub-single-digit': '8－3などの基本的なひき算',


### PR DESCRIPTION
## Summary

小学校1年生の「1桁のたし算」で、繰り上がりあり(`add-single-digit-carry`)・なし(`add-single-digit`)が別パターンに分かれておりプリント内で混在させられなかった問題を解消するため、両方が混ざる新パターン `add-single-digit-mixed`（ラベル「1桁のたし算（繰り上がり混在）」）を追加した。

## Changes Made

### Added

- `add-single-digit-mixed` パターンを追加（型・ラベル・説明・学年別パターン一覧に登録）
- 生成ロジック `generateAddSingleDigitMixed`（`src/lib/generators/patterns/grade1.ts`）: 1〜9同士の組み合わせ45通り（3＋4と4＋3は同一視）を繰り上がりの有無で2群（あり20 / なし25）に分けてFisher-Yatesシャッフルするプール方式。`count >= 2` のとき各群から1問ずつを先に確保してから残りを混合プールで埋めるため、少問数でも必ず両クラスが混在する。1枚内で組み合わせが重複しない（3列30問でも保証）。左右はランダムに入れ替える
- 難易度定義（3）を `src/config/pattern-categories.ts` に追加
- テスト6件を `src/lib/generators/patterns/grade1-beginner.test.ts` に追加（範囲と carryOver の整合、少問数を含む繰り上がり有無の混在、確保分が先頭固定でないこと、`count = 0/1` の境界、30問での組み合わせ非重複、左右順序のランダム化）

## Technical Details

### Implementation Approach

既存の reject-sampling 方式ではなく、`generateAddPlusN` と同じプール方式を採用。組み合わせの重複を確率でなく構造的に排除するため。carryOver は「和 > 10」で判定し、ちょうど10は「10をつくる計算」として繰り上がり扱いしない既存 grade1 パターンの規約に合わせている。

さらに、シャッフルしたプールを先頭から切り出すだけでは少問数のとき全問が片方のクラスに偏りうる（1列レイアウトの最小5問で約5.6% = `C(20,5)/C(45,5) + C(25,5)/C(45,5)`）。「繰り上がり混在」と銘打ったプリントとして成立しないため、45通りを繰り上がりの有無で2群に分け、`count >= 2` のとき各群から1問ずつを構造的に確保する。確保した2問はプールから取り除くので重複は起きず、また常に第1問・第2問に来ないよう選択後に出題順をシャッフルしている。

印刷テンプレートは接頭辞 `add` → `basic` カテゴリで自動導出されるため、`print-templates.ts` の変更は不要。

### Key Changes

- **`src/lib/generators/patterns/grade1.ts`** - `generateAddSingleDigitMixed` を追加（45通りをクラス別に分割したプール生成・シャッフル・各クラス最低1問の保証・重複ガード）
- **`src/types/calculation-patterns.ts`** - 型・`PATTERNS_BY_GRADE[1]`・`PATTERN_LABELS`・`PATTERN_DESCRIPTIONS` に登録
- **`src/config/pattern-categories.ts`** - 難易度3として登録
- **`src/lib/generators/patterns/index.ts`** - dispatch に追加

### Breaking Changes

なし。既存パターンには手を加えていない。

## Test Results

- `npm run lint` 成功
- `npm run typecheck` 成功
- `npm test -- --run` 674件全通過（新規6件含む）
- `npm run build` 成功
- Playwright MCP で実ブラウザ確認: 1年生「基本計算」アコーディオンに表示されること、30問3列で繰り上がりあり・なしが混在して出題されA4 1枚に収まることを目視確認済み

## Review Feedback

Codex レビューの指摘（少問数で片方のクラスだけになりうる、P2）に対応済み（`a37db02`）。上記「Implementation Approach」の後段がその修正内容。

## Review Focus

### 🟡 Important

- **難易度3の妥当性** (`src/config/pattern-categories.ts`): `add-single-digit-carry` が2、`add-sub-mixed-basic` が3。混在パターンは「繰り上がりの有無をその都度判断する」必要があるため carry(2) より上の3が妥当と判断したが、レビューをお願いしたい
- **carryOver の定義**: 既存規約通り「和=10」を carryOver=false としている（10は「10をつくる計算」扱い）。意図通りか確認をお願いしたい
- **45通り超過時の再シャッフル挙動**: `src/lib/generators/patterns/grade1.ts` に `generateAddPlusN` と同じ枯渇ガードを実装。現状 basic の最大問題数は30問（45通り以内）なので実質到達しないが、将来問題数上限が変わった際の挙動として妥当か確認をお願いしたい

### 🔵 Normal

- テストケースの網羅性（`src/lib/generators/patterns/grade1-beginner.test.ts`）

## Out of Scope Finding

検証中に本PRとは無関係の既存バグを発見した（今回は修正していない）:

URL の `?pattern=` パラメータが反映されず、必ず先頭パターン(`add-plus-one`)に上書きされる。原因は `CalculationPatternSelector.tsx:76` の「未選択なら `filteredPatterns[0]` を自動選択する」`useEffect` が、`App.tsx:46` のURLパラメータ読み込みより先に実行されるため。別issue/PRでの対応を推奨。

## Checklist

- [x] Code follows project style guidelines (lint passed)
- [x] Self-review completed
- [x] Comments added for complex logic (各クラス保証の意図と確率の根拠をコメントに明記)
- [ ] Documentation updated (CLAUDE.md のパターン追加手順に沿って登録のみ。ドキュメント本文の更新は不要と判断)
- [x] No new warnings generated
- [x] Tests added/updated
- [x] All tests pass locally (674/674)
- [x] No breaking changes
