### PR TITLE
fix(url): 共有URLの設定が復元されず既定値に戻る問題を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,9 @@ import { ProblemTypeSelector } from './components/ProblemGenerator/ProblemTypeSe
 import { CalculationPatternSelector } from './components/ProblemGenerator/CalculationPatternSelector';
 import { SettingsPanel } from './components/ProblemGenerator/SettingsPanel';
 import { WorksheetPreview } from './components/Preview/WorksheetPreview';
-import { useProblemStore, defaultSettings } from './stores/problemStore';
+import { useProblemStore } from './stores/problemStore';
 import { generateProblems } from './lib/generators';
 import {
-  parseUrlSettings,
   syncUrlFromSettings,
   getOperationFromPattern,
 } from './lib/utils/url-state';
@@ -42,7 +41,8 @@ function App(): React.ReactElement {
     }
   }, [settings, setProblems, getWorksheetData]);
 
-  // URL からの初期設定読み込み（マウント時のみ）
+  // マウント時のみ。URL の設定はストア初期化時に取り込み済みなので、
+  // ここでは古い保存データの掃除だけを行う
   useEffect(() => {
     // TODO: 将来のバージョンで削除。PR #38以前のlocalStorage設定データを清掃する一時的な処理。
     try {
@@ -50,17 +50,6 @@ function App(): React.ReactElement {
     } catch {
       // localStorage が無効な環境（プライバシーモード等）では無視
     }
-    const urlOverrides = parseUrlSettings(
-      window.location.search,
-      defaultSettings
-    );
-    if (Object.keys(urlOverrides).length > 0) {
-      updateSettings(urlOverrides);
-    } else {
-      // URL パラメータがない場合もデフォルト設定で URL を同期
-      syncUrlFromSettings(defaultSettings);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // 設定変更時に自動で問題を生成 + URL を同期

--- a/src/__tests__/url-settings-restore.test.tsx
+++ b/src/__tests__/url-settings-restore.test.tsx
@@ -75,6 +75,26 @@ describe('共有URLからの設定復元', () => {
     });
   });
 
+  it('count 未指定の URL では復元後のテンプレートの推奨問題数になる', async () => {
+    // 筆算3列の推奨・最大は12問。全体デフォルトの30問のままだと
+    // 選択肢に存在しない値になり、A4からはみ出す
+    await renderAppWithUrl('?grade=3&type=hissan&cols=3');
+
+    await waitFor(() => {
+      expect(currentParams().get('count')).toBe('12');
+    });
+  });
+
+  it('count 未指定でパターンが実効タイプを変える場合も推奨問題数になる', async () => {
+    await renderAppWithUrl(
+      '?grade=3&type=basic&pattern=hissan-mult-basic&cols=2'
+    );
+
+    await waitFor(() => {
+      expect(currentParams().get('count')).toBe('8');
+    });
+  });
+
   it('URL パラメータがない場合はデフォルト設定が URL に同期される', async () => {
     await renderAppWithUrl('');
 

--- a/src/__tests__/url-settings-restore.test.tsx
+++ b/src/__tests__/url-settings-restore.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+
+/**
+ * 共有URLの設定が復元されることの回帰テスト。
+ *
+ * 以前は「デフォルト設定で1度描画 → useEffect で URL を反映」という順序だったため、
+ * 復元前に走る初期化 effect（URLの書き戻し・パターンの自動選択・推奨問題数の適用）が
+ * URL パラメータを打ち消していた。StrictMode の再マウントで書き戻し済みの URL を
+ * 読み直すため、共有URLを開くと必ず先頭パターン・デフォルト問題数になっていた。
+ */
+
+// ストアは import 時に URL を読むため、テストごとにモジュールを読み直す
+async function renderAppWithUrl(search: string): Promise<void> {
+  window.history.replaceState(null, '', `/${search}`);
+  vi.resetModules();
+  const { default: App } = await import('../App');
+  render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
+}
+
+function currentParams(): URLSearchParams {
+  return new URLSearchParams(window.location.search);
+}
+
+describe('共有URLからの設定復元', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('URL の pattern がプレビューに反映され、URL からも消えない', async () => {
+    await renderAppWithUrl(
+      '?grade=1&type=basic&pattern=add-single-digit-mixed&cols=2&count=14'
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /1桁のたし算（繰り上がり混在）/,
+      })
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(currentParams().get('pattern')).toBe('add-single-digit-mixed');
+    });
+  });
+
+  it('URL の問題数・列数が推奨値で上書きされない', async () => {
+    await renderAppWithUrl(
+      '?grade=1&type=basic&pattern=add-single-digit-mixed&cols=2&count=14'
+    );
+
+    // 2列の推奨問題数は20。復元した14問が維持されること
+    await waitFor(() => {
+      expect(currentParams().get('count')).toBe('14');
+      expect(currentParams().get('cols')).toBe('2');
+    });
+  });
+
+  it('学年も復元される', async () => {
+    await renderAppWithUrl(
+      '?grade=3&type=basic&pattern=mult-double-digit&cols=2&count=10'
+    );
+
+    await waitFor(() => {
+      expect(currentParams().get('grade')).toBe('3');
+      expect(currentParams().get('pattern')).toBe('mult-double-digit');
+    });
+  });
+
+  it('URL パラメータがない場合はデフォルト設定が URL に同期される', async () => {
+    await renderAppWithUrl('');
+
+    await waitFor(() => {
+      expect(currentParams().get('grade')).toBe('1');
+      expect(currentParams().get('cols')).toBe('3');
+      expect(currentParams().get('count')).toBe('30');
+    });
+  });
+
+  it('不正な pattern は無視され、既定の選択にフォールバックする', async () => {
+    await renderAppWithUrl('?grade=1&type=basic&pattern=not-a-real-pattern');
+
+    await waitFor(() => {
+      expect(currentParams().get('pattern')).not.toBe('not-a-real-pattern');
+      expect(currentParams().get('pattern')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/ProblemGenerator/SettingsPanel.tsx
+++ b/src/components/ProblemGenerator/SettingsPanel.tsx
@@ -71,8 +71,20 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isWord, isWordEn, isAnzan]);
 
-  // 問題タイプまたは列数が変更されたときに推奨問題数を自動選択
+  // 問題タイプまたは列数が変更されたときに推奨問題数を自動選択。
+  // 初回マウントでは適用しない（URL から復元した問題数を上書きしてしまうため）。
+  // 「初回かどうか」ではなく直前の組み合わせを覚えることで、StrictMode の
+  // 再マウントでも値が変わっていなければ適用されない
+  const lastRecommendationRef = React.useRef<string | null>(null);
   React.useEffect(() => {
+    const key = `${effectiveProblemType}:${layoutColumns}:${recommendedCount}`;
+    const isSameAsLast = lastRecommendationRef.current === key;
+    const isInitialMount = lastRecommendationRef.current === null;
+    lastRecommendationRef.current = key;
+
+    if (isInitialMount || isSameAsLast) {
+      return;
+    }
     onProblemCountChange(recommendedCount);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [effectiveProblemType, layoutColumns, recommendedCount]);

--- a/src/stores/problemStore.ts
+++ b/src/stores/problemStore.ts
@@ -3,6 +3,8 @@ import type { Problem, WorksheetSettings, WorksheetData } from '../types';
 import { APP_CONFIG } from '../config/constants';
 import { generateProblems } from '../lib/generators';
 import { parseUrlSettings } from '../lib/utils/url-state';
+import { getEffectiveCounts } from '../config/print-templates';
+import { getEffectiveProblemType } from '../lib/utils/problem-type-detector';
 
 export type UpdateSettingsPayload = Partial<WorksheetSettings>;
 export type WorksheetBatch = WorksheetData[];
@@ -46,10 +48,28 @@ export function getInitialSettings(): WorksheetSettings {
   if (typeof window === 'undefined') {
     return defaultSettings;
   }
-  return {
-    ...defaultSettings,
-    ...parseUrlSettings(window.location.search, defaultSettings),
-  };
+  const urlOverrides = parseUrlSettings(
+    window.location.search,
+    defaultSettings
+  );
+  const settings = { ...defaultSettings, ...urlOverrides };
+
+  // count 未指定の URL では全体デフォルト（30問）が残ってしまう。
+  // 復元したテンプレートの推奨問題数に合わせる。
+  // 例: ?grade=3&type=hissan&cols=3 は筆算3列の12問が上限で、
+  // 30問のままだと問題数の選択肢に無い値になりA4からはみ出す
+  if (urlOverrides.problemCount === undefined) {
+    settings.problemCount = getEffectiveCounts(
+      getEffectiveProblemType(
+        settings.problemType,
+        settings.calculationPattern
+      ),
+      settings.calculationPattern,
+      settings.grade
+    ).recommendedCounts[settings.layoutColumns];
+  }
+
+  return settings;
 }
 
 export const useProblemStore = create<ProblemStore>()((set, get) => ({

--- a/src/stores/problemStore.ts
+++ b/src/stores/problemStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { Problem, WorksheetSettings, WorksheetData } from '../types';
 import { APP_CONFIG } from '../config/constants';
 import { generateProblems } from '../lib/generators';
+import { parseUrlSettings } from '../lib/utils/url-state';
 
 export type UpdateSettingsPayload = Partial<WorksheetSettings>;
 export type WorksheetBatch = WorksheetData[];
@@ -33,8 +34,26 @@ export const defaultSettings: WorksheetSettings = {
   layoutColumns: APP_CONFIG.defaultLayoutColumns,
 };
 
+/**
+ * 共有URLの設定を「最初の描画」から反映させるため、ストア生成時に取り込む。
+ *
+ * マウント後の useEffect で反映すると、復元前のデフォルト設定で描画される
+ * 一瞬が生まれる。その間に走る各コンポーネントの初期化 effect
+ * （パターンの自動選択・推奨問題数の自動適用・URLの書き戻し）が
+ * 復元値を打ち消してしまうため、描画前に確定させる。
+ */
+export function getInitialSettings(): WorksheetSettings {
+  if (typeof window === 'undefined') {
+    return defaultSettings;
+  }
+  return {
+    ...defaultSettings,
+    ...parseUrlSettings(window.location.search, defaultSettings),
+  };
+}
+
 export const useProblemStore = create<ProblemStore>()((set, get) => ({
-  settings: defaultSettings,
+  settings: getInitialSettings(),
   problems: [],
 
   updateSettings: (newSettings): void => {


### PR DESCRIPTION
## Summary

`?pattern=` などのクエリを付けてページを開いても設定が復元されず、必ず先頭パターン（`add-plus-one`）・デフォルト問題数・デフォルト列数に戻ってしまう問題を修正した。共有URL／ブックマークが事実上機能していなかった。

PR #78 のレビュー中に発見した既存バグで、当該PRのスコープ外として別対応にしたもの。

## 再現手順

開発サーバー（`npm run dev`）で以下を開く:

```
http://localhost:5174/?grade=1&type=basic&pattern=add-single-digit-mixed&cols=2&count=14
```

**修正前**: URLが即座に `?grade=1&type=basic&pattern=add-plus-one&cols=3&count=30` に書き換わり、プレビューも「+1のたし算・30問・3列」になる
**修正後**: URLもプレビューも `1桁のたし算（繰り上がり混在）・14問・2列` のまま

## 原因

「デフォルト設定で1度描画してから `useEffect` で URL を反映する」という順序が根本原因。復元が完了する前に各コンポーネントの初期化処理が走り、復元値を打ち消していた。3つの経路が重なっている:

1. **`App.tsx` の同期effect** — マウント時に**復元前の** `settings`（＝デフォルト）で `syncUrlFromSettings` を呼び、URLパラメータを破壊する。StrictMode の再マウントでその破壊済みURLを読み直すため、パラメータが完全に失われる
2. **`CalculationPatternSelector.tsx:76`** — 子のeffectは親より先に走るため `selectedPattern` を未選択とみなし、`filteredPatterns[0]`（＝`add-plus-one`）を自動選択する
3. **`SettingsPanel.tsx:75`** — マウント時にも推奨問題数を適用し、URLの `count` を上書きする

実測ログ（計測用に一時的に仕込んだもの、コミットには含まない）:

```
[DBG] Selector auto-select -> add-plus-one
[DBG] App mount effect, search= ?...&pattern=add-single-digit-mixed&cols=2&count=20
       overrides= {"calculationPattern":"add-single-digit-mixed","layoutColumns":2,...}   ← パースは正しい
[DBG] App sync effect, pattern= undefined cols= 3 count= 30                               ← 復元前の値でURLを上書き
[DBG] Selector auto-select -> add-plus-one                                                 ← StrictMode 2回目
[DBG] App mount effect, search= ?grade=1&type=basic&cols=3&count=30                        ← 破壊済みURLを読む
```

なお本番ビルド（StrictMode なし）では最終的に自己修復するため、URLが恒久的に壊れるのは開発時のみ。ただし本番でも「一瞬デフォルト設定でURLを上書きし、誤ったパターンで1回問題生成する」無駄な往復は発生していた。

## 修正方針

3つの経路を個別に握り潰すのではなく、**URLの設定をストア初期化時に取り込んで「復元前の描画」自体をなくす**方針を採った。最初の描画から復元済みの状態になるため、上記1〜3はいずれも復元値を壊さなくなる。

- `problemStore.ts` に `getInitialSettings()` を追加し、`create()` の初期stateで `parseUrlSettings` を適用（SSR等を考慮して `typeof window === 'undefined'` はガード）
- あわせて、URL に `count` が無い場合は復元後のテンプレート（実効タイプ・パターン・学年・列数）の推奨問題数を採用する。全体デフォルトの30問が残ると、例えば `?grade=3&type=hissan&cols=3`（筆算3列の上限は12問）で選択肢に無い値になりA4からはみ出すため
- `App.tsx` のマウントeffectから URL 読み込みを削除（残るのは旧localStorageデータの掃除のみ）。同期effectも素直な形に戻り、フラグによる制御は不要になった
- `SettingsPanel.tsx` の推奨問題数の自動適用を初回マウントではスキップ。「初回かどうか」ではなく直前の `(タイプ:列数:推奨数)` を覚えることで、StrictMode の再マウントでも値が変わっていなければ適用されない

## Key Changes

- **`src/stores/problemStore.ts`** — `getInitialSettings()` を追加し、初期stateをURL由来にする
- **`src/App.tsx`** — マウント時のURL読み込み・書き戻しロジックを削除（-15行）
- **`src/components/ProblemGenerator/SettingsPanel.tsx`** — 推奨問題数の自動適用を初回マウントで抑止
- **`src/__tests__/url-settings-restore.test.tsx`** — StrictMode 下で `<App />` を描画する回帰テスト（新規・7件）

### Breaking Changes

なし。UIからの操作挙動は変更していない。

## Test Results

- `npm run lint` / `npm run typecheck` 成功
- `npm test -- --run` **681件全通過**（新規7件含む）。フルスイートを3回連続実行して確認
- `npm run build` 成功
- **回帰テストの有効性を確認済み**: 修正コードを退避して同テストを実行すると3件が失敗する（バキュームテストでないことの確認）。レビュー指摘で追加した2件も、修正前に失敗することを確認済み
- ブラウザ実機確認（開発サーバー=StrictMode / `vite preview`=本番ビルドの両方）:
  - `?pattern=add-single-digit-mixed&cols=2&count=14` → 14問・2列・繰り上がり混在で復元 ✅
  - `?grade=3&...&pattern=hissan-mult-basic&cols=2&count=12` → `count` は 8 にクランプされる（筆算2列の上限。A4保護として意図通り）✅
  - `?grade=3&type=hissan&cols=3`（count省略）→ 筆算3列の推奨12問に正規化される ✅
  - パラメータなし → 従来どおりデフォルト設定がURLに同期される ✅
  - 列数を 2→3 に変更 → 推奨30問に追従しURLも同期（既存挙動を維持）✅

## Review Feedback

Codex レビューの指摘（`count` 省略時に全体デフォルトの30問が残り、筆算など上限の小さいテンプレートでA4をはみ出す。P2）に対応済み（`a6c6dc1`）。本PRが入れてしまった回帰で、上記「修正方針」の2点目がその内容。再レビューは指摘なし。

## Review Focus

### 🟡 Important

- **ストア初期化時に `window.location.search` を読む設計** (`src/stores/problemStore.ts`): モジュール読み込み時にURLに依存することになる。テスト環境（jsdom）では空クエリ＝デフォルトになるため既存テストへの影響はないが、この結合を許容するか意見をいただきたい。代案は「App側でフラグを持ち復元完了まで書き戻しを抑止する」形だが、経路2・3を個別に抑える必要があり脆いと判断した
- **`SettingsPanel` の初回スキップ判定** (`src/components/ProblemGenerator/SettingsPanel.tsx`): `(タイプ:列数:推奨数)` をキーにして「変化したときだけ適用」に変えている。単純な `isFirstRender` フラグでは StrictMode の再マウントを通過してしまうためこの形にした

### 🔵 Normal

- 回帰テストが `<App />` 全体を描画する点（実行時間は約0.5秒）

## Note

フルスイート実行中に `src/lib/generators/word-problem-en.test.ts` の「grade 6 should sometimes produce answers at or above 5000」が**一度だけ**失敗した。確率依存のテストで、単体13回・フルスイート3回の再実行では再現せず、本PRは文章問題のコードに一切触れていない（差分参照）。既存のflakyテストと判断し本PRでは対応していない。

## Checklist

- [x] Code follows project style guidelines (lint passed)
- [x] Self-review completed
- [x] Comments added for complex logic (初期化順序という非自明な理由をコメントに明記)
- [ ] Documentation updated (内部実装の修正のためドキュメント変更は不要と判断)
- [x] No new warnings generated
- [x] Tests added/updated
- [x] All tests pass locally (681/681)
- [x] No breaking changes

